### PR TITLE
hh-tate-mode

### DIFF
--- a/package/batocera/emulationstation/batocera-es-system/es_features.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_features.yml
@@ -1623,8 +1623,8 @@ libretro:
                 prompt: HANDHELD TATE MODE
                 description: Rotates the display and remaps inputs for device to be used sideways.
                 choices:
-                    "Off":    disabled
-                    "On":     enabled
+                    "Off":    "False"
+                    "On":     "True"
             fbneo-lightgun-hide-crosshair:
                 group: LIGHT GUN
                 prompt:      SHOW LIGHT GUN CROSSHAIRS
@@ -2561,8 +2561,8 @@ libretro:
                 prompt: HANDHELD TATE MODE
                 description: Rotates the display and remaps inputs for device to be used sideways.
                 choices:
-                    "Off":    disabled
-                    "On":     enabled
+                    "Off":    "False"
+                    "On":     "True"
             hiscoreplugin:
                 group: ADVANCED OPTIONS
                 prompt:      HIGH SCORE PLUGIN


### PR DESCRIPTION
Adds handheld tate mode es settings and code to libretroConfig.

Currently for rg35xx/h, rg28xx, and trimui smart pro handhelds. For additional handhelds note that checks need to be added for gamepad guid/device name, and board name from batocera-info, then add input remaps.