### PR TITLE
Memory Leak fix for the RG28xx

### DIFF
--- a/board/batocera/allwinner/h700/rg28xx/patches/sdl2/0002-mali-fbdev-Implemented-MALI-Zero-Copy-fbdev-rotation.patch
+++ b/board/batocera/allwinner/h700/rg28xx/patches/sdl2/0002-mali-fbdev-Implemented-MALI-Zero-Copy-fbdev-rotation.patch
@@ -1765,5 +1765,5 @@ index 000000000..c7df119d1
 +#endif /* __MALI_H__ */
 \ No newline at end of file
 -- 
-2.20.1
+2.20.
 

--- a/board/batocera/allwinner/h700/rg28xx/patches/sdl2/0006-refactoring.patch
+++ b/board/batocera/allwinner/h700/rg28xx/patches/sdl2/0006-refactoring.patch
@@ -1,0 +1,110 @@
+From bf714de28568d258ed9ae3758bf940b4bbee5c1a Mon Sep 17 00:00:00 2001
+From: JohnnyonFlame <johnnyonflame@hotmail.com>
+Date: Wed, 12 Jun 2024 21:38:32 -0300
+Subject: [PATCH] Correct the swap order for the blitter buffers. This has no
+ effect in functionality, but fixes the naming scheme.
+
+---
+ src/video/mali-fbdev/SDL_maliblitter.c  | 8 ++++----
+ src/video/mali-fbdev/SDL_maliopengles.c | 4 ++--
+ 2 files changed, 6 insertions(+), 6 deletions(-)
+
+diff --git a/src/video/mali-fbdev/SDL_maliblitter.c b/src/video/mali-fbdev/SDL_maliblitter.c
+index 403a077df..16b753dbb 100644
+--- a/src/video/mali-fbdev/SDL_maliblitter.c
++++ b/src/video/mali-fbdev/SDL_maliblitter.c
+@@ -501,12 +501,12 @@ int MALI_BlitterThread(void *data)
+         }
+ 
+         /* Flip the most recent back buffer with the front buffer */
+-        page = windata->queued_buffer;
+-        windata->queued_buffer = windata->front_buffer;
+-        windata->front_buffer = page;
++        page = windata->front_buffer;
++        windata->front_buffer = windata->queued_buffer;
++        windata->queued_buffer = page;
+ 
+         /* select surface to wait and blit */
+-        current_surface = &windata->surface[windata->queued_buffer];
++        current_surface = &windata->surface[windata->front_buffer];
+ 
+         /* wait for fence and flip display */
+         if (blitter->eglClientWaitSyncKHR(
+diff --git a/src/video/mali-fbdev/SDL_maliopengles.c b/src/video/mali-fbdev/SDL_maliopengles.c
+index f16a2f76f..e14602dde 100644
+--- a/src/video/mali-fbdev/SDL_maliopengles.c
++++ b/src/video/mali-fbdev/SDL_maliopengles.c
+@@ -63,8 +63,8 @@ int MALI_GLES_SwapWindow(_THIS, SDL_Window * window)
+    windowdata->surface[windowdata->back_buffer].egl_fence = _this->egl_data->eglCreateSyncKHR(_this->egl_data->egl_display, EGL_SYNC_FENCE_KHR, NULL);
+ 
+    // Flip back and front buffers
+-   prev = windowdata->front_buffer;
+-   windowdata->front_buffer = windowdata->back_buffer;
++   prev = windowdata->queued_buffer;
++   windowdata->queued_buffer = windowdata->back_buffer;
+    windowdata->back_buffer = prev;
+ 
+    // Done, update back buffer surfaces
+diff --git a/src/video/mali-fbdev/SDL_maliblitter.c b/src/video/mali-fbdev/SDL_maliblitter.c
+index 16b753dbb..b8d6df177 100644
+--- a/src/video/mali-fbdev/SDL_maliblitter.c
++++ b/src/video/mali-fbdev/SDL_maliblitter.c
+@@ -466,6 +466,7 @@ int MALI_BlitterThread(void *data)
+         if (blitter->thread_stop != 0) {
+             if (blitter->was_initialized) {
+                 MALI_DeinitBlitterContext(_this, blitter);
++                prevSwapInterval = -1;
+             }
+ 
+             // Done tearing down.
+diff --git a/src/video/mali-fbdev/SDL_maliblitter.c b/src/video/mali-fbdev/SDL_maliblitter.c
+index b8d6df177..6aa9d8f4e 100644
+--- a/src/video/mali-fbdev/SDL_maliblitter.c
++++ b/src/video/mali-fbdev/SDL_maliblitter.c
+@@ -513,7 +513,7 @@ int MALI_BlitterThread(void *data)
+         if (blitter->eglClientWaitSyncKHR(
+             blitter->egl_display,
+             current_surface->egl_fence, 
+-            EGL_SYNC_FLUSH_COMMANDS_BIT_KHR, 
++            0,
+             EGL_FOREVER_NV))
+         {
+             /* Discarding previous data... */
+diff --git a/src/video/mali-fbdev/SDL_maliopengles.c b/src/video/mali-fbdev/SDL_maliopengles.c
+index e14602dde..7819f2da1 100644
+--- a/src/video/mali-fbdev/SDL_maliopengles.c
++++ b/src/video/mali-fbdev/SDL_maliopengles.c
+@@ -56,6 +56,7 @@ int MALI_GLES_SwapWindow(_THIS, SDL_Window * window)
+       return SDL_EGL_SwapBuffers(_this, ((SDL_WindowData *)window->driverdata)->egl_surface);
+ 
+    windowdata = (SDL_WindowData*)_this->windows->driverdata;
++   windowdata->glFlush();
+ 
+    SDL_LockMutex(blitter->mutex);
+ 
+diff --git a/src/video/mali-fbdev/SDL_malivideo.c b/src/video/mali-fbdev/SDL_malivideo.c
+index 43279ffea..8c40a1a4f 100644
+--- a/src/video/mali-fbdev/SDL_malivideo.c
++++ b/src/video/mali-fbdev/SDL_malivideo.c
+@@ -334,6 +334,9 @@ MALI_EGL_InitPixmapSurfaces(_THIS, SDL_Window *window)
+         }
+     }
+ 
++    /* Acquire an entry point to the glFlush function used to flush the buffered commands on "swap". */
++    windowdata->glFlush = SDL_GL_GetProcAddress("glFlush");
++
+     /* Reconfigure the blitter now. */
+     MALI_BlitterReconfigure(_this, window, displaydata->blitter);
+ 
+diff --git a/src/video/mali-fbdev/SDL_malivideo.h b/src/video/mali-fbdev/SDL_malivideo.h
+index 3fad6e795..6d894b17c 100644
+--- a/src/video/mali-fbdev/SDL_malivideo.h
++++ b/src/video/mali-fbdev/SDL_malivideo.h
+@@ -76,6 +76,7 @@ typedef struct SDL_WindowData
+     int front_buffer;
+ 
+     MALI_EGL_Surface surface[3];
++    void (*glFlush)(void);
+ } SDL_WindowData;
+ 
+ /****************************************************************************/

--- a/board/batocera/allwinner/h700/rg28xx/patches/sdl2/0007-no-MSAA.patch
+++ b/board/batocera/allwinner/h700/rg28xx/patches/sdl2/0007-no-MSAA.patch
@@ -1,0 +1,25 @@
+From ebe911a7b1aa1e42fa1d147817c58d05565c820a Mon Sep 17 00:00:00 2001
+From: JohnnyonFlame <johnnyonflame@hotmail.com>
+Date: Wed, 12 Jun 2024 23:23:42 -0300
+Subject: [PATCH] Workaround to fix performance regression when the blitter is
+ enabled. Unfortunately MSAA on Pixmap surfaces cause major performance
+ regressions even on low sample sizes and very small framebuffers. Disable
+ MSAA when the blitter is used to workaround this issue.
+
+---
+ src/video/mali-fbdev/SDL_malivideo.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/src/video/mali-fbdev/SDL_malivideo.c b/src/video/mali-fbdev/SDL_malivideo.c
+index 8c40a1a4f..35d82cf98 100644
+--- a/src/video/mali-fbdev/SDL_malivideo.c
++++ b/src/video/mali-fbdev/SDL_malivideo.c
+@@ -252,6 +252,8 @@ MALI_EGL_InitPixmapSurfaces(_THIS, SDL_Window *window)
+     width = window->w;
+     height = window->h;
+ 
++    _this->gl_config.multisamplebuffers = 0;
++    _this->gl_config.multisamplesamples = 0;
+     _this->egl_data->egl_surfacetype = EGL_PIXMAP_BIT;
+     if (SDL_EGL_ChooseConfig(_this) != 0) {
+         SDL_SetError("mali-fbdev: Unable to find a suitable EGL config");

--- a/board/batocera/allwinner/h700/rg28xx/patches/sdl2/0008-add-sRGB.patch
+++ b/board/batocera/allwinner/h700/rg28xx/patches/sdl2/0008-add-sRGB.patch
@@ -1,0 +1,49 @@
+From 0bdf3b3e5d64f43f1092d6224d722b7f67a514ae Mon Sep 17 00:00:00 2001
+From: JohnnyonFlame <johnnyonflame@hotmail.com>
+Date: Thu, 13 Jun 2024 04:46:58 -0300
+Subject: [PATCH] Add support for sRGB colorspace on maliblitter.
+
+---
+ src/video/mali-fbdev/SDL_malivideo.c | 15 +++++++++++++--
+ 1 file changed, 13 insertions(+), 2 deletions(-)
+
+diff --git a/src/video/mali-fbdev/SDL_malivideo.c b/src/video/mali-fbdev/SDL_malivideo.c
+index 35d82cf98..5de6ff169 100644
+--- a/src/video/mali-fbdev/SDL_malivideo.c
++++ b/src/video/mali-fbdev/SDL_malivideo.c
+@@ -244,7 +244,8 @@ MALI_EGL_InitPixmapSurfaces(_THIS, SDL_Window *window)
+     struct ion_allocation_data allocation_data;
+     SDL_DisplayData *displaydata;
+     SDL_WindowData *windowdata; 
+-    int i, io, width, height;
++    int i, io, width, height, attr = 0;
++    GLint surf_attribs[3] = {};
+ 
+     windowdata = window->driverdata;
+     displaydata = SDL_GetDisplayDriverData(0);
+@@ -260,6 +261,15 @@ MALI_EGL_InitPixmapSurfaces(_THIS, SDL_Window *window)
+         return EGL_NO_SURFACE;
+     }
+ 
++    /* Did we request a sRGB surface? */
++    if (_this->gl_config.framebuffer_srgb_capable) {
++        surf_attribs[attr++] = EGL_GL_COLORSPACE_KHR;
++        surf_attribs[attr++] = EGL_GL_COLORSPACE_SRGB_KHR;
++    }
++
++    //end the EGL Surface attribute list
++    surf_attribs[attr] = EGL_NONE;
++
+     SDL_LogInfo(SDL_LOG_CATEGORY_VIDEO, "mali-fbdev: Creating Pixmap (%dx%d) buffers", width, height);
+     windowdata->back_buffer = 0;
+     windowdata->queued_buffer = 1;
+@@ -329,7 +339,8 @@ MALI_EGL_InitPixmapSurfaces(_THIS, SDL_Window *window)
+         surf->egl_surface = _this->egl_data->eglCreatePixmapSurface(
+             _this->egl_data->egl_display,
+             _this->egl_data->egl_config,
+-            surf->pixmap_handle, NULL);
++            surf->pixmap_handle,
++            surf_attribs);
+         if (surf->egl_surface == EGL_NO_SURFACE) {
+             SDL_EGL_SetError("mali-fbdev: Unable to create EGL window surface", "eglCreatePixmapSurface");
+             return EGL_NO_SURFACE;

--- a/board/batocera/allwinner/h700/rg28xx/patches/sdl2/0009-memleak-fix.patch
+++ b/board/batocera/allwinner/h700/rg28xx/patches/sdl2/0009-memleak-fix.patch
@@ -1,0 +1,127 @@
+From 6599ce7a96409c1da6f34792646c191e2e2407fe Mon Sep 17 00:00:00 2001
+From: JohnnyonFlame <johnnyonflame@hotmail.com>
+Date: Fri, 14 Jun 2024 13:08:27 -0300
+Subject: [PATCH] Workaround for memory leak caused by fences not being
+ destroyed.
+
+---
+ src/video/mali-fbdev/SDL_maliblitter.c  |  7 +++++++
+ src/video/mali-fbdev/SDL_maliopengles.c | 10 ++++++++++
+ src/video/mali-fbdev/SDL_malivideo.c    |  2 ++
+ 3 files changed, 19 insertions(+)
+
+diff --git a/src/video/mali-fbdev/SDL_maliblitter.c b/src/video/mali-fbdev/SDL_maliblitter.c
+index 6aa9d8f4e..6fc3fd7a6 100644
+--- a/src/video/mali-fbdev/SDL_maliblitter.c
++++ b/src/video/mali-fbdev/SDL_maliblitter.c
+@@ -516,6 +516,13 @@ int MALI_BlitterThread(void *data)
+             0,
+             EGL_FOREVER_NV))
+         {
++            /* 
++                JohnnyonFlame: Mali bug. If we don't manually destroy the fence here
++                this is going to leak and crash.
++            */
++            blitter->eglDestroySyncKHR(blitter->egl_display, current_surface->egl_fence);
++            current_surface->egl_fence = EGL_NO_SYNC;
++
+             /* Discarding previous data... */
+             blitter->glClear(GL_COLOR_BUFFER_BIT);
+ 
+diff --git a/src/video/mali-fbdev/SDL_maliopengles.c b/src/video/mali-fbdev/SDL_maliopengles.c
+index 7819f2da1..d99e33558 100644
+--- a/src/video/mali-fbdev/SDL_maliopengles.c
++++ b/src/video/mali-fbdev/SDL_maliopengles.c
+@@ -68,6 +68,16 @@ int MALI_GLES_SwapWindow(_THIS, SDL_Window * window)
+    windowdata->queued_buffer = windowdata->back_buffer;
+    windowdata->back_buffer = prev;
+ 
++   // Do we have anything left over from the previous frame?
++   if (windowdata->surface[windowdata->back_buffer].egl_fence != EGL_NO_SYNC) {
++      _this->egl_data->eglDestroySyncKHR(
++         _this->egl_data->egl_display,
++         windowdata->surface[windowdata->back_buffer].egl_fence
++      );
++
++      windowdata->surface[windowdata->back_buffer].egl_fence = EGL_NO_SYNC;
++   }
++
+    // Done, update back buffer surfaces
+    surf = windowdata->surface[windowdata->back_buffer].egl_surface;
+    windowdata->egl_surface = surf;
+diff --git a/src/video/mali-fbdev/SDL_malivideo.c b/src/video/mali-fbdev/SDL_malivideo.c
+index 5de6ff169..a13375c55 100644
+--- a/src/video/mali-fbdev/SDL_malivideo.c
++++ b/src/video/mali-fbdev/SDL_malivideo.c
+@@ -345,6 +345,8 @@ MALI_EGL_InitPixmapSurfaces(_THIS, SDL_Window *window)
+             SDL_EGL_SetError("mali-fbdev: Unable to create EGL window surface", "eglCreatePixmapSurface");
+             return EGL_NO_SURFACE;
+         }
++
++        surf->egl_fence = EGL_NO_SYNC;
+     }
+ 
+     /* Acquire an entry point to the glFlush function used to flush the buffered commands on "swap". */
+diff --git a/src/video/mali-fbdev/SDL_maliblitter.c b/src/video/mali-fbdev/SDL_maliblitter.c
+index 6fc3fd7a6..c91f2b191 100644
+--- a/src/video/mali-fbdev/SDL_maliblitter.c
++++ b/src/video/mali-fbdev/SDL_maliblitter.c
+@@ -249,11 +249,6 @@ MALI_InitBlitterContext(_THIS, MALI_Blitter *blitter, SDL_WindowData *windata, N
+     const GLchar *sources[2] = { blit_vert, blit_frag_standard };
+     float scale[2];
+ 
+-    /* Bail out early if we're already initialized. */
+-    if (blitter->was_initialized) {
+-        return 1;
+-    }
+-
+     /*
+      * SDL_HQ_SCALER: Selects one of the available scalers:
+      * - 0: Nearest filtering
+@@ -445,12 +440,12 @@ int MALI_BlitterThread(void *data)
+     int prevSwapInterval = -1;
+     MALI_Blitter *blitter = (MALI_Blitter*)data;
+     _THIS = blitter->_this;
+-    SDL_Window *window;
+-    SDL_WindowData *windata;
+-    SDL_VideoDisplay *display;
++    SDL_Window *window = NULL;
++    SDL_WindowData *windata = NULL;
++    SDL_VideoDisplay *display = NULL;
+     SDL_DisplayData *dispdata = SDL_GetDisplayDriverData(0);
+     unsigned int page;
+-    MALI_EGL_Surface *current_surface;
++    MALI_EGL_Surface *current_surface = NULL;
+     
+     MALI_Blitter_LoadFuncs(blitter);
+ 
+@@ -484,16 +479,20 @@ int MALI_BlitterThread(void *data)
+             continue;
+         }
+ 
+-        window = blitter->window;
+-        windata = (SDL_WindowData *)window->driverdata;
+-        display = SDL_GetDisplayForWindow(window);
+-        dispdata = (SDL_DisplayData *)display->driverdata;
+-
+-        /* Initialize blitter on the first out frame we have */
+-        if (!MALI_InitBlitterContext(_this, blitter, windata, (NativeWindowType)&dispdata->native_display, blitter->rotation))
++        /* If we haven't initialized the blitter, the first valid frame does it. */
++        if (blitter->was_initialized == 0)
+         {
+-            SDL_LogError(SDL_LOG_CATEGORY_VIDEO, "Failed to initialize blitter thread");
+-            SDL_Quit();
++            /* Acquire pointers for the resources needed here. */
++            window = blitter->window;
++            windata = (SDL_WindowData *)window->driverdata;
++            display = SDL_GetDisplayForWindow(window);
++            dispdata = (SDL_DisplayData *)display->driverdata;
++
++            if (!MALI_InitBlitterContext(_this, blitter, windata, (NativeWindowType)&dispdata->native_display, blitter->rotation))
++            {
++                SDL_LogError(SDL_LOG_CATEGORY_VIDEO, "Failed to initialize blitter thread");
++                SDL_Quit();
++            }            
+         }
+ 
+         if (prevSwapInterval != _this->egl_data->egl_swapinterval) {


### PR DESCRIPTION
adding several patches from @JohnnyonFlame to fix the memroy leak in RA. these patches includes:
- disabling MSAA in blittering.
- add sRGB support
- a workaround for the memory leak. fixes the issue


These patches are specific to the RG28xx as its still using blitter for the rotation part. 