### PR TITLE
update-rcs-faster-boot-hdmi-out

### DIFF
--- a/board/batocera/allwinner/h700/fsoverlay/etc/init.d/S27debugmount
+++ b/board/batocera/allwinner/h700/fsoverlay/etc/init.d/S27debugmount
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+# Mount debugfs
+mount -t debugfs debugfs /sys/kernel/debug
+if [ $? -eq 0 ]; then
+    logger "debugfs successfully mounted."
+else
+    logger "Failed to mount debugfs."
+    exit 1
+fi

--- a/board/batocera/allwinner/h700/fsoverlay/usr/bin/batocera-resolution
+++ b/board/batocera/allwinner/h700/fsoverlay/usr/bin/batocera-resolution
@@ -27,6 +27,7 @@ check_hdmi() {
 setOutput() {
     if check_hdmi; then
         # 720p external
+        cat /dev/zero > /dev/fb0
         echo disp0 > $display/name
         echo switch1 > $display/command
         echo 4 5 0 0 0x4 0x201 0 1 0 8 > $display/param
@@ -34,6 +35,7 @@ setOutput() {
         fbset -g 1280 720 1280 1440 32 -t 13426 192 56 22 1 136 3
     else
         # 480p internal
+        cat /dev/zero > /dev/fb0
         echo disp0 > $display/name
         echo switch > $display/command
         echo 1 0 > $display/param

--- a/board/batocera/allwinner/h700/fsoverlay/usr/bin/hdmi_audio_switch.sh
+++ b/board/batocera/allwinner/h700/fsoverlay/usr/bin/hdmi_audio_switch.sh
@@ -19,20 +19,6 @@ if check_ingame; then
     exit 1
 fi
 
-# Check if debugfs is mounted
-if grep -qs 'debugfs' /proc/mounts; then
-    echo "debugfs is mounted." >> /var/log/hdmi-event.log
-else
-    echo "debugfs is not mounted. Attempting to mount..." >> /var/log/hdmi-event.log
-    mount -t debugfs debugfs /sys/kernel/debug
-    if [ $? -eq 0 ]; then
-        echo "debugfs successfully mounted." >> /var/log/hdmi-event.log
-    else
-        echo "Failed to mount debugfs." >> /var/log/hdmi-event.log
-        exit 1
-    fi
-fi
-
 kill_es() {
 	killall emulationstation 2>/dev/null
 	killall touchegg 2>/dev/null

--- a/board/batocera/allwinner/h700/rg28xx/fsoverlay/etc/init.d/rcS
+++ b/board/batocera/allwinner/h700/rg28xx/fsoverlay/etc/init.d/rcS
@@ -28,12 +28,17 @@ for i in /etc/init.d/S??* ;do
 		trap - INT QUIT TSTP
 		set start
 		. $i
-	    )
+	    ) &
 	    ;;
 	*)
-	    echo "$i" > /tmp/status.txt
-	    # No sh extension, so fork subprocess.
-	    $i start
+	    case "$i" in
+	        *S05udev | *S06audio | *S11share) # Don't run these in background
+	            $i start
+	            ;;
+	        *)
+	            $i start &
+	            ;;
+	    esac
 	    ;;
     esac
 

--- a/board/batocera/allwinner/h700/rg35xx-plus/fsoverlay/etc/init.d/rcS
+++ b/board/batocera/allwinner/h700/rg35xx-plus/fsoverlay/etc/init.d/rcS
@@ -25,12 +25,17 @@ for i in /etc/init.d/S??* ;do
 		trap - INT QUIT TSTP
 		set start
 		. $i
-	    )
+	    ) &
 	    ;;
 	*)
-	    echo "$i" > /tmp/status.txt
-	    # No sh extension, so fork subprocess.
-	    $i start
+	    case "$i" in
+	        *S05udev | *S06audio | *S11share) # Don't run these in background
+	            $i start
+	            ;;
+	        *)
+	            $i start &
+	            ;;
+	    esac
 	    ;;
     esac
 


### PR DESCRIPTION
Updates rcS to load init scripts in background as a default. Excludes specific ones that cause problems and shouldn't be.

updated hdmi switching.