### PR TITLE
Add `wlan*` for ETHMAC for `batocera-encode` and use of pkdf2

### DIFF
--- a/package/batocera/core/batocera-scripts/scripts/batocera-encode
+++ b/package/batocera/core/batocera-scripts/scripts/batocera-encode
@@ -2,7 +2,7 @@
 
 # use to hide password from people having no access to the ssh connection
 # based on unique values of you rpi :
-#    * based on the mac address of the ethernet card (so, not for rpi0) - not secure for people having access to the local network, but for people having access to your external drive or batocera.conf file
+#    * based on the mac address of the ethernet or wireless card - not secure for people having access to the local network, but for people having access to your external drive or batocera.conf file
 #    * based on the rpi serial number - limited security while it's only 8 numbers and guessable partially i think
 
 ACTION=$1
@@ -10,7 +10,8 @@ CODE=$2
 
 getPassword() {
     SERIAL=$(grep -E '^Serial' /proc/cpuinfo | sed -e s+'^Serial[\t]*: '++)
-    ETHMAC=$(cat /sys/class/net/eth*/address)
+	# Falls back to using wlan* if no eth* is found and mutes the printing of "No such file or directory"
+	ETHMAC=$(cat /sys/class/net/eth*/address 2>/dev/null || cat /sys/class/net/wlan*/address 2>/dev/null)
     echo "${SERIAL}${ETHMAC}"
 }
 
@@ -19,7 +20,7 @@ case "${ACTION}" in
 	if echo "${CODE}" | grep -qE '^enc:'
 	then
 	    PASSWORD=$(getPassword)
-	    if ! echo "${CODE}" | sed -e s+"^enc:"++ | openssl enc -aes-128-cbc -a -d -salt -pass pass:"${PASSWORD}"
+	    if ! echo "${CODE}" | sed -e s+"^enc:"++ | openssl enc -aes-128-cbc -a -d -salt -pass pass:"${PASSWORD} -pbkdf2"
 	    then
 		exit 1
 	    fi
@@ -30,7 +31,7 @@ case "${ACTION}" in
 
     "encode")
 	PASSWORD=$(getPassword)
-	CODE=$(echo "${CODE}" | openssl enc -aes-128-cbc -a -salt -pass pass:"${PASSWORD}")
+	CODE=$(echo "${CODE}" | openssl enc -aes-128-cbc -a -salt -pass pass:"${PASSWORD}" -pbkdf2)
 	echo "enc:${CODE}"
     ;;
 esac


### PR DESCRIPTION
Resolves error at root password change #79 

 - Adding the `wlan` adapter MACs as a fallback in case no `eth` devices are present
 - Using pbkdf2 as key derivation (instead of the default deprecated one) for `openssl enc`