### PR TITLE
Updated EmulationStation

### DIFF
--- a/batocera-Changelog.md
+++ b/batocera-Changelog.md
@@ -1,6 +1,8 @@
 # 2024/xx/xx - batocera.linux 40 -
 ### Special Notes
 The standalone Citra emulator has migrated to it's successor, Lemonade emulator. You should be able to move your saves from /userdata/saves/3ds/citra to the equivalent lemonade directory.
+
+EmulationStation's Video Mode (resolution) is now under System Settings rather than under Frontend Developers.
 ### Hardware
 Add support for the Pironman case with RPI4 devices.
 Add support for OrangePi Zero 3 (all variants)

--- a/configs/batocera-board.common
+++ b/configs/batocera-board.common
@@ -65,8 +65,8 @@ BR2_INIT_SYSV=y
 BR2_ROOTFS_DEVICE_CREATION_DYNAMIC_EUDEV=y
 BR2_TARGET_GENERIC_ROOT_PASSWD="linux"
 BR2_SYSTEM_ENABLE_NLS=y
-BR2_ENABLE_LOCALE_WHITELIST="C ar ca cs_CZ cy cy_GB cy de en el es es_MX eu eu_ES fr fr_FR fi_FI he hu id_ID it ja ja_JP ja ko nb nb_NO nl nn nn_NO oc oc_FR pl pt pt_PT pt_BR ru ru_RU uk uk_UA sk_SK sv sv_SE tr vi_VN zh zh_CN zh_TW"
-BR2_GENERATE_LOCALE="en_US.UTF-8 ar_YE.UTF-8 ca_ES.UTF-8 cs_CZ.UTF-8 cy_GB.UTF-8 de_DE.UTF-8 el_GR.UTF-8 en_GB.UTF-8 es_ES.UTF-8 es_MX.UTF-8 eu_ES.UTF-8 fr_FR.UTF-8 fi_FI.UTF-8 he_IL.UTF-8 hu_HU.UTF-8 id_ID.UTF-8 it_IT.UTF-8 ja_JP.UTF-8 ko_KR.UTF-8 nb_NO.UTF-8 nl_NL.UTF-8 nn_NO.UTF-8 oc_FR.UTF-8 pl_PL.UTF-8 pt_BR.UTF-8 pt_PT.UTF-8 ru_RU.UTF-8 uk_UA.UTF-8 sk_SK.UTF-8 sv_SE.UTF-8 tr_TR.UTF-8 vi_VN.UTF-8 zh_CN.UTF-8 zh_TW.UTF-8"
+BR2_ENABLE_LOCALE_WHITELIST="C ar ca cs_CZ cy cy_GB cy de en el es es_MX eu eu_ES fr fr_FR fi_FI gl_ES he hu id_ID it ja ja_JP ja ko nb nb_NO nl nn nn_NO oc oc_FR pl pt pt_PT pt_BR ru ru_RU uk uk_UA ro_RO sk_SK sv sv_SE tr vi_VN zh zh_CN zh_TW"
+BR2_GENERATE_LOCALE="en_US.UTF-8 ar_YE.UTF-8 ca_ES.UTF-8 cs_CZ.UTF-8 cy_GB.UTF-8 de_DE.UTF-8 el_GR.UTF-8 en_GB.UTF-8 es_ES.UTF-8 es_MX.UTF-8 eu_ES.UTF-8 fr_FR.UTF-8 fi_FI.UTF-8 gl_ES.UTF-8 he_IL.UTF-8 hu_HU.UTF-8 id_ID.UTF-8 it_IT.UTF-8 ja_JP.UTF-8 ko_KR.UTF-8 nb_NO.UTF-8 nl_NL.UTF-8 nn_NO.UTF-8 oc_FR.UTF-8 pl_PL.UTF-8 pt_BR.UTF-8 pt_PT.UTF-8 ru_RU.UTF-8 uk_UA.UTF-8 ro_RO.UTF-8 sk_SK.UTF-8 sv_SE.UTF-8 tr_TR.UTF-8 vi_VN.UTF-8 zh_CN.UTF-8 zh_TW.UTF-8"
 BR2_TARGET_TZ_INFO=y
 BR2_TARGET_LOCALTIME="Europe/Paris"
 # BR2_TARGET_GENERIC_REMOUNT_ROOTFS_RW is not set

--- a/package/batocera/emulationstation/batocera-emulationstation/batocera-emulationstation.mk
+++ b/package/batocera/emulationstation/batocera-emulationstation/batocera-emulationstation.mk
@@ -3,8 +3,8 @@
 # batocera-emulationstation
 #
 ################################################################################
-# Last update: Commits on June 17, 2024
-BATOCERA_EMULATIONSTATION_VERSION = 23acaf003367c12eb85f63f39b9e8127fdb3fbc2
+# Last update: Commits on July 19, 2024
+BATOCERA_EMULATIONSTATION_VERSION = 0261e73a172fcc6e01f73c9d5988f60bc0cb40fd
 BATOCERA_EMULATIONSTATION_SITE = https://github.com/batocera-linux/batocera-emulationstation
 BATOCERA_EMULATIONSTATION_SITE_METHOD = git
 BATOCERA_EMULATIONSTATION_LICENSE = MIT


### PR DESCRIPTION
- Fixed Retroachievements
- Video Mode (resolution) is now under System Settings rather than under Frontend Developers

I have tested the changes on my device, they are working.

This will fix #39 