### PR TITLE
Fix Typo in `batocera-encode`

### DIFF
--- a/package/batocera/core/batocera-scripts/scripts/batocera-encode
+++ b/package/batocera/core/batocera-scripts/scripts/batocera-encode
@@ -20,7 +20,7 @@ case "${ACTION}" in
 	if echo "${CODE}" | grep -qE '^enc:'
 	then
 	    PASSWORD=$(getPassword)
-	    if ! echo "${CODE}" | sed -e s+"^enc:"++ | openssl enc -aes-128-cbc -a -d -salt -pass pass:"${PASSWORD} -pbkdf2"
+	    if ! echo "${CODE}" | sed -e s+"^enc:"++ | openssl enc -aes-128-cbc -a -d -salt -pass pass:"${PASSWORD}" -pbkdf2
 	    then
 		exit 1
 	    fi


### PR DESCRIPTION
I had a bad typo on the last fix, I had not tested the changes by building a new image (and the typo was not present when I tested it on the device...).

Now that I can build my own builds, I tested it and found the typo (or misplacement of the argument .. such a stupid mistake :sweat_smile: .. sorry)