### PR TITLE
Added squashfs to MSU1 and Satellaview

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroGenerator.py
@@ -14,6 +14,7 @@ from settings.unixSettings import UnixSettings
 from utils.logger import get_logger
 import utils.videoMode as videoMode
 import shutil
+import glob
 
 eslog = get_logger(__name__)
 
@@ -237,7 +238,7 @@ class LibretroGenerator(Generator):
         elif system.name == 'vitaquake2':
             directory_path = os.path.dirname(rom)
             if "xatrix" in directory_path:
-                system.config['core'] = "vitaquake2-xatrix"            
+                system.config['core'] = "vitaquake2-xatrix"
             elif "rogue" in directory_path:
                 system.config['core'] = "vitaquake2-rogue"
             elif "zaero" in directory_path:
@@ -256,7 +257,7 @@ class LibretroGenerator(Generator):
             # choose core based on new rom directory
             directory_path = os.path.dirname(rom)
             if "d3xp" in directory_path:
-                system.config['core'] = "boom3_xp" 
+                system.config['core'] = "boom3_xp"
             retroarchCore = batoceraFiles.retroarchCores + system.config['core'] + "_libretro.so"
             commandArray = [batoceraFiles.batoceraBins[system.config['emulator']], "-L", retroarchCore, "--config", system.config['configfile']]
         # super mario wars - verify assets from Content Downloader
@@ -287,9 +288,9 @@ class LibretroGenerator(Generator):
             commandArray = [batoceraFiles.batoceraBins[system.config['emulator']], "-L", retroarchCore, "--config", system.config['configfile']]
         else:
             commandArray = [batoceraFiles.batoceraBins[system.config['emulator']], "-L", retroarchCore, "--config", system.config['configfile']]
-        
+
         configToAppend = []
-        
+
         # Custom configs - per core
         customCfg = f"{batoceraFiles.retroarchRoot}/{system.name}.cfg"
         if os.path.isfile(customCfg):
@@ -334,21 +335,26 @@ class LibretroGenerator(Generator):
             romName = os.path.splitext(os.path.basename(rom))[0]
             rom = batoceraFiles.daphneDatadir + '/roms/' + romName +'.zip'
 
+        if system.name == 'snes-msu1' or system.name == 'satellaview':
+            if "squashfs" in rom:
+                romsInDir = glob.glob(glob.escape(rom) + '/*.sfc') + glob.glob(glob.escape(rom) + '/*.smc')
+                rom = romsInDir[0]
+
         if system.name == 'scummvm':
             rom = os.path.dirname(rom) + '/' + romName[0:-8]
-        
+
         if system.name == 'reminiscence':
             with open(rom, 'r') as file:
                 first_line = file.readline().strip()
             directory_path = '/'.join(rom.split('/')[:-1])
             rom = f"{directory_path}/{first_line}"
-        
+
         if system.name == 'openlara':
             with open(rom, 'r') as file:
                 first_line = file.readline().strip()
             directory_path = '/'.join(rom.split('/')[:-1])
             rom = f"{directory_path}/{first_line}"
-                
+
         # Use command line instead of ROM file for MAME variants
         if system.config['core'] in [ 'mame', 'mess', 'mamevirtual', 'same_cdi' ]:
             dontAppendROM = True
@@ -360,7 +366,7 @@ class LibretroGenerator(Generator):
 
         if dontAppendROM == False:
             commandArray.append(rom)
-            
+
         return Command.Command(array=commandArray, env={"XDG_CONFIG_HOME":batoceraFiles.CONF})
 
 def getGFXBackend(system):

--- a/package/batocera/emulationstation/batocera-es-system/es_systems.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_systems.yml
@@ -25,7 +25,7 @@ snes-msu1:
   manufacturer: Nintendo
   release: 1991
   hardware: console
-  extensions: [smc, sfc]
+  extensions: [smc, sfc, squashfs]
   group:      snes
   emulators:
     libretro:
@@ -2155,7 +2155,7 @@ satellaview:
   manufacturer: Nintendo
   release: 1995
   hardware: console
-  extensions: [bs, smc, sfc, zip, 7z]
+  extensions: [bs, smc, sfc, zip, 7z, squashfs]
   group:      snes
   emulators:
     libretro:


### PR DESCRIPTION
This PR adds the squashfs extension to MSU1 and Satellaview, which has some benefits:
- It uses only one file instead of a folder structure, which give a better overview.
- You can rename the file, if you do that in a msu1 structure you need to rename all the files.
- It adds compression which saves some space