### PR TITLE
Disable hud for flycast - fixes ability to launch flycast on TSP

### DIFF
--- a/package/batocera/core/batocera-configgen/configs/configgen-defaults.yml
+++ b/package/batocera/core/batocera-configgen/configs/configgen-defaults.yml
@@ -162,6 +162,8 @@ dos:
 dreamcast:
   emulator: libretro
   core:     flycast
+  options:
+    hud_support: false
 dxx-rebirth:
   emulator: dxx-rebirth
   core:     dxx-rebirth


### PR DESCRIPTION
Closes #57 

It's been well reported that on the Trimui Smart Pro you cannot launch any Dreamcast games using Knulli. When attempting to use the standalone Flycast emulator there is an error log generated that states that mangohud cannot be found. The  setting change in this PR stops emulatorlauncher from attempting to start mangohud when starting Flycast. Flycast then starts fine on TSP devices.