### PR TITLE
Libretro ScummVM: Persisting in-game settings (volume, subtitles, etc.)

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroGenerator.py
@@ -335,7 +335,10 @@ class LibretroGenerator(Generator):
             rom = batoceraFiles.daphneDatadir + '/roms/' + romName +'.zip'
 
         if system.name == 'scummvm':
-            rom = os.path.dirname(rom) + '/' + romName[0:-8]
+            rom = os.path.dirname(rom) + '/' + romName
+            if os.stat(rom).st_size == 0:
+                # File is empty, run game directly
+                rom = rom[0:-8]
         
         if system.name == 'reminiscence':
             with open(rom, 'r') as file:


### PR DESCRIPTION
Hi there!

I have made a minor fix to the way Batocera handles libretro ScummVM games. I proposed this change to the Batocera project as a PR, where it was already accepted and merged into the master branch, so this small change will hit Knulli at some point anyway. (Click here to see the original PR, including an explanation how I came up with the solution and why I think it is required and will not break anything: https://github.com/batocera-linux/batocera.linux/pull/12190)

However, since I play a lot of ScummVM recently, I currently need to keep this change in an overlay on my own device so that I can play my games properly. It is not a big issue, however, now that Batocera accepted my fix, I decided to offer the feature as a PR to Knulli, too. Just in case that you wont be able to review the 1258 other commits we are currently behind anytime soon, I figured maybe you'd like to adopt my tiny fix directly, just so that the issue is fixed.

I don't mind if you decline, I can keep it in the overlay, of course! Still, I felt like I should propose it.