### PR TITLE
Switch between toggle FF and hold FF in ES (for RetroArch cores only)

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroControllers.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroControllers.py
@@ -32,15 +32,13 @@ systemToSwapDisable = {'amigacd32', 'amigacdtv', 'naomi', 'atomiswave', 'megadri
 def writeControllersConfig(retroconfig, system, controllers, lightgun):
     # Map buttons to the corresponding retroarch specials keys
     retroarchspecials = {'x': 'load_state', 'y': 'save_state', 'a': 'reset', 'start': 'exit_emulator', \
-                         'up': 'state_slot_increase', 'down': 'state_slot_decrease', 'left': 'rewind', \
+                         'up': 'state_slot_increase', 'down': 'state_slot_decrease', 'left': 'rewind', 'right': 'hold_fast_forward', \
                          'pageup': 'screenshot', 'pagedown': 'ai_service', 'l2': 'shader_prev', 'r2': 'shader_next'}
     retroarchspecials["b"] = "menu_toggle"
 
-    # Assign hotkey + right to either toggle fast forward or hold fast forward
+    # Assign hotkey + right to toggle fast forward if the option is set
     if system.isOptSet('toggle_fast_forward') and system.getOptBoolean("toggle_fast_forward") == True:
         retroarchspecials["right"] = "toggle_fast_forward"
-    else:
-        retroarchspecials["right"] = "hold_fast_forward"
 
     # Some input adaptations for some systems with swap Disc/CD
     if (system.config['core'] in coreWithSwapSupport) and (system.name not in systemToSwapDisable):

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroControllers.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroControllers.py
@@ -32,12 +32,12 @@ systemToSwapDisable = {'amigacd32', 'amigacdtv', 'naomi', 'atomiswave', 'megadri
 def writeControllersConfig(retroconfig, system, controllers, lightgun):
     # Map buttons to the corresponding retroarch specials keys
     retroarchspecials = {'x': 'load_state', 'y': 'save_state', 'a': 'reset', 'start': 'exit_emulator', \
-                         'up': 'state_slot_increase', 'down': 'state_slot_decrease', 'left': 'rewind', 'right': 'hold_fast_forward', \
+                         'up': 'state_slot_increase', 'down': 'state_slot_decrease', 'left': 'rewind', \
                          'pageup': 'screenshot', 'pagedown': 'ai_service', 'l2': 'shader_prev', 'r2': 'shader_next'}
     retroarchspecials["b"] = "menu_toggle"
 
-    # toggle or hold to fast forward
-    if system.isOptSet('fast_forward') and system.config['fast_forward'] == 'toggle':
+    # Replace hold fast forward with toggle fast forward
+    if system.isOptSet('toggle_fast_forward') and system.getOptBoolean("toggle_fast_forward") == True:
         retroarchspecials["right"] = "toggle_fast_forward"
     else:
         retroarchspecials["right"] = "hold_fast_forward"

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroControllers.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroControllers.py
@@ -36,14 +36,10 @@ def writeControllersConfig(retroconfig, system, controllers, lightgun):
                          'pageup': 'screenshot', 'pagedown': 'ai_service', 'l2': 'shader_prev', 'r2': 'shader_next'}
     retroarchspecials["b"] = "menu_toggle"
 
-    # Toggle or hold special key to fast forward
-    if system.isOptSet('fast_forward'):
-        if system.config['fast_forward'] == 'toggle':
-            retroarchspecials["right"] = "toggle_fast_forward"
-        if system.config['fast_forward'] == 'hold':
-            retroarchspecials["right"] = "hold_fast_forward"
+    # toggle or hold to fast forward
+    if system.isOptSet('fast_forward') and system.config['fast_forward'] == 'toggle':
+        retroarchspecials["right"] = "toggle_fast_forward"
     else:
-        # If unclear, default to hold
         retroarchspecials["right"] = "hold_fast_forward"
 
     # Some input adaptations for some systems with swap Disc/CD

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroControllers.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroControllers.py
@@ -36,7 +36,7 @@ def writeControllersConfig(retroconfig, system, controllers, lightgun):
                          'pageup': 'screenshot', 'pagedown': 'ai_service', 'l2': 'shader_prev', 'r2': 'shader_next'}
     retroarchspecials["b"] = "menu_toggle"
 
-    # Replace hold fast forward with toggle fast forward
+    # Assign hotkey + right to either toggle fast forward or hold fast forward
     if system.isOptSet('toggle_fast_forward') and system.getOptBoolean("toggle_fast_forward") == True:
         retroarchspecials["right"] = "toggle_fast_forward"
     else:

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroControllers.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroControllers.py
@@ -36,10 +36,14 @@ def writeControllersConfig(retroconfig, system, controllers, lightgun):
                          'pageup': 'screenshot', 'pagedown': 'ai_service', 'l2': 'shader_prev', 'r2': 'shader_next'}
     retroarchspecials["b"] = "menu_toggle"
 
-    # toggle or hold to fast forward
-    if system.isOptSet('fast_forward') and system.config['fast_forward'] == 'toggle':
-        retroarchspecials["right"] = "toggle_fast_forward"
+    # Toggle or hold special key to fast forward
+    if system.isOptSet('fast_forward'):
+        if system.config['fast_forward'] == 'toggle':
+            retroarchspecials["right"] = "toggle_fast_forward"
+        if system.config['fast_forward'] == 'hold':
+            retroarchspecials["right"] = "hold_fast_forward"
     else:
+        # If unclear, default to hold
         retroarchspecials["right"] = "hold_fast_forward"
 
     # Some input adaptations for some systems with swap Disc/CD

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroControllers.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroControllers.py
@@ -36,6 +36,12 @@ def writeControllersConfig(retroconfig, system, controllers, lightgun):
                          'pageup': 'screenshot', 'pagedown': 'ai_service', 'l2': 'shader_prev', 'r2': 'shader_next'}
     retroarchspecials["b"] = "menu_toggle"
 
+    # toggle or hold to fast forward
+    if system.isOptSet('fast_forward') and system.config['fast_forward'] == 'toggle':
+        retroarchspecials["right"] = "toggle_fast_forward"
+    else:
+        retroarchspecials["right"] = "hold_fast_forward"
+
     # Some input adaptations for some systems with swap Disc/CD
     if (system.config['core'] in coreWithSwapSupport) and (system.name not in systemToSwapDisable):
         retroarchspecials["pageup"] = "disk_eject_toggle"
@@ -49,7 +55,7 @@ def writeControllersConfig(retroconfig, system, controllers, lightgun):
                             '7':  'rewind',              '8':  'hold_fast_forward', '9': 'screenshot', \
                             '10': 'disk_prev',           '11': 'disk_next',         '12': 'disk_eject_toggle', \
                             '13': 'shader_prev',         '14': 'shader_next',       '15': 'ai_service', \
-                            '16': 'menu_toggle'}
+                            '16': 'menu_toggle',         '17': 'toggle_fast_forward'}
     cleanControllerConfig(retroconfig, controllers, retroarchFullSpecial)
 
     # No menu in non full uimode

--- a/package/batocera/emulationstation/batocera-es-system/es_features.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_features.yml
@@ -70,12 +70,10 @@ shared:
       choices:
         "On":  1
         "Off": 0
-    fast_forward:
-      prompt: FAST FORWARD
-      description: Switch between holding fast forward and toggling fast forward, if the core supports it.
-      choices:
-        "Toggle":  toggle
-        "Hold": hold
+    toggle_fast_forward:
+      prompt: TOGGLE FAST FORWARD
+      description: Enable to toggle fast forward instead of holding it down.
+      preset: switch
     autosave:
       prompt: AUTO SAVE/LOAD ON GAME LAUNCH
       description: Load latest save state on game launch and save state when exiting game.
@@ -335,7 +333,7 @@ shared:
         "hidden": "hidden"
 
 global:
-  shared: [powermode, tdp, videomode, ratio, shaderset, smooth, integerscale, bezel, bezel_stretch, hud, hud_corner, bezel.tattoo, bezel.tattoo_corner, bezel.tattoo_file, bezel.resize_tattoo, ai_service_enabled, ai_target_lang, ai_service_url, ai_service_pause, rewind, fast_forward, runahead, preemptiveframes, secondinstance, video_frame_delay_auto, vrr_runloop_enable, video_threaded, rumble_gain]
+  shared: [powermode, tdp, videomode, ratio, shaderset, smooth, integerscale, bezel, bezel_stretch, hud, hud_corner, bezel.tattoo, bezel.tattoo_corner, bezel.tattoo_file, bezel.resize_tattoo, ai_service_enabled, ai_target_lang, ai_service_url, ai_service_pause, rewind, toggle_fast_forward, runahead, preemptiveframes, secondinstance, video_frame_delay_auto, vrr_runloop_enable, video_threaded, rumble_gain]
 
 libretro:
   shared: [powermode, tdp, videomode, ratio, shaderset, smooth, integerscale, bezel, bezel_stretch, hud, hud_corner, bezel.tattoo, bezel.tattoo_corner, bezel.tattoo_file, bezel.resize_tattoo, ai_service_enabled, ai_target_lang, ai_service_url, ai_service_pause, runahead, preemptiveframes, secondinstance, video_frame_delay_auto, vrr_runloop_enable, video_threaded, rumble_gain, audio_volume, bordersmode]

--- a/package/batocera/emulationstation/batocera-es-system/es_features.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_features.yml
@@ -335,7 +335,7 @@ shared:
         "hidden": "hidden"
 
 global:
-  shared: [powermode, tdp, videomode, ratio, shaderset, smooth, integerscale, bezel, bezel_stretch, hud, hud_corner, bezel.tattoo, bezel.tattoo_corner, bezel.tattoo_file, bezel.resize_tattoo, ai_service_enabled, ai_target_lang, ai_service_url, ai_service_pause, rewind, toggle_fast_forward, runahead, preemptiveframes, secondinstance, video_frame_delay_auto, vrr_runloop_enable, video_threaded, rumble_gain]
+  shared: [powermode, tdp, videomode, ratio, shaderset, smooth, integerscale, bezel, bezel_stretch, hud, hud_corner, bezel.tattoo, bezel.tattoo_corner, bezel.tattoo_file, bezel.resize_tattoo, ai_service_enabled, ai_target_lang, ai_service_url, ai_service_pause, rewind, fast_forward, runahead, preemptiveframes, secondinstance, video_frame_delay_auto, vrr_runloop_enable, video_threaded, rumble_gain]
 
 libretro:
   shared: [powermode, tdp, videomode, ratio, shaderset, smooth, integerscale, bezel, bezel_stretch, hud, hud_corner, bezel.tattoo, bezel.tattoo_corner, bezel.tattoo_file, bezel.resize_tattoo, ai_service_enabled, ai_target_lang, ai_service_url, ai_service_pause, runahead, preemptiveframes, secondinstance, video_frame_delay_auto, vrr_runloop_enable, video_threaded, rumble_gain, audio_volume, bordersmode]

--- a/package/batocera/emulationstation/batocera-es-system/es_features.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_features.yml
@@ -70,6 +70,12 @@ shared:
       choices:
         "On":  1
         "Off": 0
+    fast_forward:
+      prompt: FAST FORWARD
+      description: Switch between holding fast forward and toggling fast forward, if the core supports it.
+      choices:
+        "Toggle":  toggle
+        "Hold": hold
     autosave:
       prompt: AUTO SAVE/LOAD ON GAME LAUNCH
       description: Load latest save state on game launch and save state when exiting game.
@@ -329,7 +335,7 @@ shared:
         "hidden": "hidden"
 
 global:
-  shared: [powermode, tdp, videomode, ratio, shaderset, smooth, integerscale, bezel, bezel_stretch, hud, hud_corner, bezel.tattoo, bezel.tattoo_corner, bezel.tattoo_file, bezel.resize_tattoo, ai_service_enabled, ai_target_lang, ai_service_url, ai_service_pause, rewind, runahead, preemptiveframes, secondinstance, video_frame_delay_auto, vrr_runloop_enable, video_threaded, rumble_gain]
+  shared: [powermode, tdp, videomode, ratio, shaderset, smooth, integerscale, bezel, bezel_stretch, hud, hud_corner, bezel.tattoo, bezel.tattoo_corner, bezel.tattoo_file, bezel.resize_tattoo, ai_service_enabled, ai_target_lang, ai_service_url, ai_service_pause, rewind, toggle_fast_forward, runahead, preemptiveframes, secondinstance, video_frame_delay_auto, vrr_runloop_enable, video_threaded, rumble_gain]
 
 libretro:
   shared: [powermode, tdp, videomode, ratio, shaderset, smooth, integerscale, bezel, bezel_stretch, hud, hud_corner, bezel.tattoo, bezel.tattoo_corner, bezel.tattoo_file, bezel.resize_tattoo, ai_service_enabled, ai_target_lang, ai_service_url, ai_service_pause, runahead, preemptiveframes, secondinstance, video_frame_delay_auto, vrr_runloop_enable, video_threaded, rumble_gain, audio_volume, bordersmode]

--- a/package/batocera/emulationstation/batocera-es-system/es_features.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_features.yml
@@ -72,8 +72,10 @@ shared:
         "Off": 0
     toggle_fast_forward:
       prompt: TOGGLE FAST FORWARD
-      description: Enable to toggle fast forward instead of holding it down.
-      preset: switch
+      description: Enable to toggle fast forward instead of holding it down. Only on libretro cores.
+      choices:
+        "On":  1
+        "Off": 0
     autosave:
       prompt: AUTO SAVE/LOAD ON GAME LAUNCH
       description: Load latest save state on game launch and save state when exiting game.
@@ -336,7 +338,7 @@ global:
   shared: [powermode, tdp, videomode, ratio, shaderset, smooth, integerscale, bezel, bezel_stretch, hud, hud_corner, bezel.tattoo, bezel.tattoo_corner, bezel.tattoo_file, bezel.resize_tattoo, ai_service_enabled, ai_target_lang, ai_service_url, ai_service_pause, rewind, toggle_fast_forward, runahead, preemptiveframes, secondinstance, video_frame_delay_auto, vrr_runloop_enable, video_threaded, rumble_gain]
 
 libretro:
-  shared: [powermode, tdp, videomode, ratio, shaderset, smooth, integerscale, bezel, bezel_stretch, hud, hud_corner, bezel.tattoo, bezel.tattoo_corner, bezel.tattoo_file, bezel.resize_tattoo, ai_service_enabled, ai_target_lang, ai_service_url, ai_service_pause, runahead, preemptiveframes, secondinstance, video_frame_delay_auto, vrr_runloop_enable, video_threaded, rumble_gain, audio_volume, bordersmode]
+  shared: [powermode, tdp, videomode, ratio, shaderset, smooth, integerscale, bezel, bezel_stretch, hud, hud_corner, bezel.tattoo, bezel.tattoo_corner, bezel.tattoo_file, bezel.resize_tattoo, ai_service_enabled, ai_target_lang, ai_service_url, ai_service_pause, toggle_fast_forward, runahead, preemptiveframes, secondinstance, video_frame_delay_auto, vrr_runloop_enable, video_threaded, rumble_gain, audio_volume, bordersmode]
   cfeatures:
     gfxbackend:
       archs_include: [x86, x86_64, bcm2711, bcm2712]


### PR DESCRIPTION
### Summary

I added a new global option to ES which allows to set **FAST FORWARD** to either **Hold** or **Toggle**. Based on this setting, Libretro will use *Function* + *D-pad right* either for holding FF or for toggling FF.

### Motivation

Some users complained about having to hold *Function* + *D-pad right* and wanted to be able to use that hotkey combo to toggle FF instead. It is possible to set this up via `batocera.conf` by directly passing the RetroArch settings, however, that is somewhat annoying:

```
global.retroarch.input_hold_fast_forward_btn = nul
global.retroarch.input_toggle_fast_forward_btn = "h0right"
```

Personally, I don't care for fast forward anyway, but I figured some users might enjoy being able to achieve this in an easier way. 

### Proposed solution

I introduced a new global setting `global.fast_forward` to `es_features.yml` that can be set to either `hold` or `toggle`.

Within `libretroControllers.py` I use that setting to decide whether *Function* + *D-pad right* should be bound to `hold_fast_forward` (as it was before) or to `toggle_fast_forward` instead. If no value is set, it will default to `hold_fast_forward` so that no user would be surprised by a change in behavior.

I also made sure that both `hold_fast_forward` and `toggle_fast_forward` are cleared, so that there won't be any confusing behavior with both being bound at the same time.
