### PR TITLE
feat: create separate save states folder

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/batoceraFiles.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/batoceraFiles.py
@@ -54,6 +54,7 @@ retroarchCoreCustom = retroarchRoot + "/cores/retroarch-core-options.cfg"
 retroarchCores = "/usr/lib/libretro/"
 screenshotsDir = "/userdata/screenshots/"
 savesDir = "/userdata/saves/"
+statesDir = "/userdata/states/"
 
 mupenConf = CONF + '/mupen64/'
 mupenCustom = mupenConf + "mupen64plus.cfg"

--- a/package/batocera/core/batocera-configgen/configgen/configgen/emulatorlauncher.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/emulatorlauncher.py
@@ -211,6 +211,11 @@ def start_rom(args, maxnbplayers, rom, romConfiguration):
         if not os.path.exists(dirname):
             os.makedirs(dirname)
 
+        # statesdir: create the save states directory if not exists
+        dirname = os.path.join(batoceraFiles.statesDir, system.name)
+        if not os.path.exists(dirname):
+            os.makedirs(dirname)
+
         # core
         effectiveCore = ""
         if "core" in system.config and system.config["core"] is not None:

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroConfig.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroConfig.py
@@ -204,7 +204,7 @@ def createLibretroConfig(generator, system, controllers, metadata, guns, wheels,
 
     retroarchConfig['sort_savefiles_enable'] = 'false'     # ensure we don't save system.name + core
     retroarchConfig['sort_savestates_enable'] = 'false'    # ensure we don't save system.name + core
-    retroarchConfig['savestate_directory'] = batoceraFiles.savesDir + system.name
+    retroarchConfig['savestate_directory'] = batoceraFiles.statesDir + system.name
     retroarchConfig['savefile_directory'] = batoceraFiles.savesDir + system.name
 
     # Forced values (so that if the config is not correct, fix it)


### PR DESCRIPTION
Create separate retroarch save states folder for:

1. Aligment with other retroarch systems (android, rocknix, arkos, muos, ...);
2. Better usage with syncthing

![image](https://github.com/user-attachments/assets/c7523a7a-3fc1-4e30-8514-f25dd4b72d18)
