### PR TITLE
Fix stereo audio output for RG35XXSP

### DIFF
--- a/board/batocera/allwinner/h700/fsoverlay/usr/bin/batocera-audio
+++ b/board/batocera/allwinner/h700/fsoverlay/usr/bin/batocera-audio
@@ -69,7 +69,7 @@ case "${ACTION}" in
                         amixer -c 0 sset "OutputL Mixer DACR" off
                         amixer -c 0 sset "OutputR Mixer DACL" off
                         amixer -c 0 sset "OutputR Mixer DACR" on
-                    elif [ "$BOARD" == "rg35xx-h" ] || [ "$BOARD" == "rg40xx" ]; then
+                    elif [ "$BOARD" == "rg35xx-h" ] || [ "$BOARD" == "rg35xx-sp" ] || [ "$BOARD" == "rg40xx" ]; then
                         MODE=alsa_output._sys_devices_platform_soc_soc_03000000_codec_mach_sound_card0.stereo-fallback
                         LANG=C pactl set-default-sink "${MODE}" || exit 1
                         amixer -c 0 sset "OutputL Mixer DACL" on


### PR DESCRIPTION
Currently in the RG35XXSP, audio from the headphone jack is outputting as mono.

This PR applies the audio settings implemented on the RG35XXH and RG40XX boards to the RG35XXSP as well.