### PR TITLE
knulli-screenshot - change default filename

### DIFF
--- a/board/batocera/fsoverlay/usr/bin/knulli-screenshot
+++ b/board/batocera/fsoverlay/usr/bin/knulli-screenshot
@@ -1,17 +1,21 @@
 #!/bin/sh
 
 #knulli-screenshot 20241105 by dopaz for Knulli
+#20241115 change default filename (include resolution)
+
+#get the width
+FB_WIDTH=$(fbset | grep "geometry" | awk '{print $2}')
+
+#get the height
+FB_HEIGHT=$(fbset | grep "geometry" | awk '{print $3}')
 
 #use the first argument as the output filename
 FILE=$1
 #if the first argument does not result in a valid filename...
 if [ -z ${FILE} ]; then
 	#generate a filename
-    FILE=/userdata/screenshots/knulli-screenshot_$(date +%Y%m%d_%Hh%Mm%Ss).png
+    FILE=/userdata/screenshots/knulli-screenshot_${FB_WIDTH}x${FB_HEIGHT}_$(date +%Y%m%d_%Hh%Mm%Ss).png
 fi
-#get the width
-FB_WIDTH=$(fbset | grep "geometry" | awk '{print $2}')
-#get the height
-FB_HEIGHT=$(fbset | grep "geometry" | awk '{print $3}')
+
 #call fbgrab, ignore the alpha channel
 fbgrab -a -w ${FB_WIDTH} -h ${FB_HEIGHT} -l ${FB_WIDTH} "${FILE}" 2>/dev/null || exit 1


### PR DESCRIPTION
if no screenshot filename is provided, the generated one will include the width and height of the framebuffer, i.e. knulli-screenshot_1280x720_20241115_12h03m25s.png  