### PR TITLE
Added missing boardchecks for RG CubeXX for LED restart and LED achievement effect

### DIFF
--- a/board/batocera/allwinner/h700/fsoverlay/etc/pm/sleep.d/99-postresume-jsled
+++ b/board/batocera/allwinner/h700/fsoverlay/etc/pm/sleep.d/99-postresume-jsled
@@ -3,7 +3,7 @@
 SERVICES=$(batocera-settings-get system.services)
 BOARD=$(cat /boot/boot/batocera.board)
 # We only want the script to run for these devices
-if [ "$BOARD" != "rg40xx-h" ] && [ "$BOARD" != "rg40xx-v" ]; then
+if [ "$BOARD" != "rg40xx-h" ] && [ "$BOARD" != "rg40xx-v" ] && [ "$BOARD" != "rg-cubexx" ]; then
     exit 1
 fi
 

--- a/board/batocera/allwinner/h700/fsoverlay/usr/share/emulationstation/scripts/achievements/led.sh
+++ b/board/batocera/allwinner/h700/fsoverlay/usr/share/emulationstation/scripts/achievements/led.sh
@@ -2,7 +2,7 @@
 
 BOARD=$(cat /boot/boot/batocera.board)
 # We only want the script to run for these devices
-if [ "$BOARD" != "rg40xx-h" ] && [ "$BOARD" != "rg40xx-v" ]; then
+if [ "$BOARD" != "rg40xx-h" ] && [ "$BOARD" != "rg40xx-v" ] && [ "$BOARD" != "rg-cubexx" ]; then
     exit 1
 fi
 


### PR DESCRIPTION
Pretty sure these boardchecks are mandatory for the CubeXX users.