### PR TITLE
es-theme-knulli updated to v1.8.1

### DIFF
--- a/package/batocera/emulationstation/es-theme-knulli/es-theme-knulli.mk
+++ b/package/batocera/emulationstation/es-theme-knulli/es-theme-knulli.mk
@@ -3,8 +3,8 @@
 # EmulationStation theme "Knulli"
 #
 ################################################################################
-# Version: Commits on November 27, 2024
-ES_THEME_KNULLI_VERSION = aef48d76bf92c9b86d19eebba349763d01edf8b9
+# Version: Commits on November 28, 2024
+ES_THEME_KNULLI_VERSION = ff4b40f5b69013a3497fa9c13e664f8a7385537c
 ES_THEME_KNULLI_SITE = $(call github,symbuzzer,es-theme-knulli,$(ES_THEME_KNULLI_VERSION))
 
 define ES_THEME_KNULLI_INSTALL_TARGET_CMDS

--- a/package/batocera/emulationstation/es-theme-knulli/es-theme-knulli.mk
+++ b/package/batocera/emulationstation/es-theme-knulli/es-theme-knulli.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 # Version: Commits on November 28, 2024
-ES_THEME_KNULLI_VERSION = ff4b40f5b69013a3497fa9c13e664f8a7385537c
+ES_THEME_KNULLI_VERSION = 3f25460d3f1c12bde5a6aecd52679a214aae4d74
 ES_THEME_KNULLI_SITE = $(call github,symbuzzer,es-theme-knulli,$(ES_THEME_KNULLI_VERSION))
 
 define ES_THEME_KNULLI_INSTALL_TARGET_CMDS


### PR DESCRIPTION
I'm really sorry for sending PRs all the time. This will probably be the last PR I send for a while. I didn't plan on sending the last 4 PRs, v1.7.0 would have been enough. However, since both 1.7.1 and 1.8.1 fixed major issues and batocera was added to the official repo, I had to make changes to 1.8.0. Everything seems fine for now.