### PR TITLE
es-theme-knulli updated to v1.9.2 and removed Batocera user manual

### DIFF
--- a/package/batocera/core/batocera-notice/batocera-notice.mk
+++ b/package/batocera/core/batocera-notice/batocera-notice.mk
@@ -3,12 +3,12 @@
 # Batocera notice
 #
 ################################################################################
-BATOCERA_NOTICE_VERSION = e6241340d292dee20406a0567262a78ff34d45f7
-BATOCERA_NOTICE_SITE = $(call github,batocera-linux,batocera-notice,$(BATOCERA_NOTICE_VERSION))
+# BATOCERA_NOTICE_VERSION = e6241340d292dee20406a0567262a78ff34d45f7
+# BATOCERA_NOTICE_SITE = $(call github,batocera-linux,batocera-notice,$(BATOCERA_NOTICE_VERSION))
 
-define BATOCERA_NOTICE_INSTALL_TARGET_CMDS
-    mkdir -p $(TARGET_DIR)/usr/share/batocera/doc
-    cp -r $(@D)/notice.pdf $(TARGET_DIR)/usr/share/batocera/doc/notice.pdf
-endef
-
-$(eval $(generic-package))
+# define BATOCERA_NOTICE_INSTALL_TARGET_CMDS
+#     mkdir -p $(TARGET_DIR)/usr/share/batocera/doc
+#     cp -r $(@D)/notice.pdf $(TARGET_DIR)/usr/share/batocera/doc/notice.pdf
+# endef
+# 
+# $(eval $(generic-package))

--- a/package/batocera/core/batocera-notice/batocera-notice.mk
+++ b/package/batocera/core/batocera-notice/batocera-notice.mk
@@ -5,7 +5,7 @@
 ################################################################################
 # BATOCERA_NOTICE_VERSION = e6241340d292dee20406a0567262a78ff34d45f7
 # BATOCERA_NOTICE_SITE = $(call github,batocera-linux,batocera-notice,$(BATOCERA_NOTICE_VERSION))
-
+#
 # define BATOCERA_NOTICE_INSTALL_TARGET_CMDS
 #     mkdir -p $(TARGET_DIR)/usr/share/batocera/doc
 #     cp -r $(@D)/notice.pdf $(TARGET_DIR)/usr/share/batocera/doc/notice.pdf

--- a/package/batocera/emulationstation/es-theme-knulli/es-theme-knulli.mk
+++ b/package/batocera/emulationstation/es-theme-knulli/es-theme-knulli.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 # Version: Commits on December 01, 2024
-ES_THEME_KNULLI_VERSION = 3aa11fb69342b01074f66f56a2912083954b72e5
+ES_THEME_KNULLI_VERSION = 97fcfc375bed7855a1506fa6d69a3385bcd63c08
 ES_THEME_KNULLI_SITE = $(call github,symbuzzer,es-theme-knulli,$(ES_THEME_KNULLI_VERSION))
 
 define ES_THEME_KNULLI_INSTALL_TARGET_CMDS

--- a/package/batocera/emulationstation/es-theme-knulli/es-theme-knulli.mk
+++ b/package/batocera/emulationstation/es-theme-knulli/es-theme-knulli.mk
@@ -3,8 +3,8 @@
 # EmulationStation theme "Knulli"
 #
 ################################################################################
-# Version: Commits on November 29, 2024
-ES_THEME_KNULLI_VERSION = c921a4c2022f78e9234928e00445b4eecf6669a2
+# Version: Commits on November 30, 2024
+ES_THEME_KNULLI_VERSION = 8ed80a9bb1e57df2c4c11a8380ecd0f407189bea
 ES_THEME_KNULLI_SITE = $(call github,symbuzzer,es-theme-knulli,$(ES_THEME_KNULLI_VERSION))
 
 define ES_THEME_KNULLI_INSTALL_TARGET_CMDS

--- a/package/batocera/emulationstation/es-theme-knulli/es-theme-knulli.mk
+++ b/package/batocera/emulationstation/es-theme-knulli/es-theme-knulli.mk
@@ -3,8 +3,8 @@
 # EmulationStation theme "Knulli"
 #
 ################################################################################
-# Version: Commits on November 30, 2024
-ES_THEME_KNULLI_VERSION = 8ed80a9bb1e57df2c4c11a8380ecd0f407189bea
+# Version: Commits on December 01, 2024
+ES_THEME_KNULLI_VERSION = 3aa11fb69342b01074f66f56a2912083954b72e5
 ES_THEME_KNULLI_SITE = $(call github,symbuzzer,es-theme-knulli,$(ES_THEME_KNULLI_VERSION))
 
 define ES_THEME_KNULLI_INSTALL_TARGET_CMDS


### PR DESCRIPTION
# es-theme-knulli changelog:
## v1.9.2
- Added missing Music logo espacally for Rocknix H700
- Removed unnecassary m3u files
## v1.9.1
- Grid size is setted 3x3 when auto selected on rg cubexx devices (Thanks to Raincityblues)
- Added new system logos: Vircon32
- Added new auto game collection logos: Spinner and Trackball
- The complexity of the system selection screen has been simplified

# About removing Batocera user manual
Feel free to ignore this if you want. But it is not usefull for Knulli at the moment. I tested this code change and when usr/share/batocera/docs/notice.pdf is removed, SHOW USER MANUAL option from QUICK ACCESS menu is hidden automatically.