### PR TITLE
add-disable-option-to-battery-saver

### DIFF
--- a/board/batocera/allwinner/h700/fsoverlay/usr/bin/battery-saver.sh
+++ b/board/batocera/allwinner/h700/fsoverlay/usr/bin/battery-saver.sh
@@ -13,8 +13,8 @@ LOOP_COUNT=0 # This should always be 0
 JS_DEVICES=()
 
 MODE="$(/usr/bin/batocera-settings-get system.batterysavermode)"
-if [[ -z "$MODE" || ! "$MODE" =~ ^(dim|suspend|shutdown)$ ]]; then
-    MODE="dim" # default can be dim|suspend|shutdown
+if [[ -z "$MODE" || ! "$MODE" =~ ^(disable|dim|suspend|shutdown)$ ]]; then
+    MODE="dim" # default can be disable|dim|suspend|shutdown
     /usr/bin/batocera-settings-set system.batterysavermode "$MODE"
 fi
 
@@ -53,6 +53,10 @@ js_update() {
 }
 
 do_inactivity() {
+    if [ "$MODE" = "disable" ]; then
+        return
+    fi
+	
     STATE="inactive"
     case "$MODE" in
         dim)
@@ -79,6 +83,10 @@ do_inactivity() {
 }
 
 do_activity() {
+    if [ "$MODE" = "disable" ]; then
+        return
+    fi
+	
     if [ "$MODE" = "dim" ]; then
         STATE="active"
         batocera-brightness $BRIGHTNESS


### PR DESCRIPTION
This change is particularly useful for devices like RG35XXSP, which I use as a screensaver.
The default dim mode made it difficult to use the device for that purpose.

I'm unsure if the added option is exposed in emulationstation's GUI.
Please let me know if there are additional codes that need adjustments.