### PR TITLE
Additional Logging to S20connman

### DIFF
--- a/board/batocera/fsoverlay/etc/init.d/S20connman
+++ b/board/batocera/fsoverlay/etc/init.d/S20connman
@@ -1,12 +1,15 @@
 #!/bin/sh
 
+SCRIPT_NAME=S20connman
 ### choose configuration file
 BATOCONF="/userdata/system/batocera.conf"
 BOOTCONF="/boot/batocera-boot.conf"
-DEBUGLOG=/userdata/system/logs/S20connman.log
+DEBUG_LOG=/userdata/system/logs/S20connman.log
 
 #  add -d to DEBUG_MODE to put connman into debug mode, you'll also need to adjust syslog
 #  have connman log to syslog.
+#
+#  NOTE: This is not yet working.
 DEBUG_MODE=
 
 # if /userdata is not yet available
@@ -49,6 +52,7 @@ batocera_hostname() {
 
 # configure wifi files, always
 batocera_wifi_configure() {
+    echo "$SCRIPT_NAME: batocera_wifi_configure" >> $DEBUG_LOG
     X=$1
 
     settings_hide=false; settings_name="${X}"
@@ -58,6 +62,11 @@ batocera_wifi_configure() {
     settings_ssid="$(/usr/bin/batocera-settings-get -f "$BATOCONF" wifi${X}.ssid)"
     settings_key="$(/usr/bin/batocera-settings-get -f "$BATOCONF" wifi${X}.key)"
     settings_file="/var/lib/connman/batocera_wifi${X}.config"
+
+    #  Disabled as this will log your SSID details which may not be wanted by users.
+    #echo "$SCRIPT_NAME: batocera_wifi_configure: ssid: $settings_ssid" >> $DEBUG_LOG
+    #echo "$SCRIPT_NAME: batocera_wifi_configure: ssid: $settings_key" >> $DEBUG_LOG
+    #echo "$SCRIPT_NAME: batocera_wifi_configure: ssid: $settings_file" >> $DEBUG_LOG
 
     if [ -n "${settings_key}" ]; then
         optionalPassphrase="Passphrase=${settings_key}"
@@ -83,7 +92,7 @@ batocera_wifi_configure() {
 }
 
 wifi_configure_all() {
-    echo "    Wifi Configure All" >> $DEBUGLOG
+    echo "$SCRIPT_NAME: wifi_configure_all:" >> $DEBUG_LOG
 
     for i in 1 2 3 .hidden; do
         batocera_wifi_configure "$i"
@@ -116,71 +125,62 @@ ENABLE_RETRY_COUNT=1
 DELAY_ENABLE_TO_SCAN=1
 
 wifi_enable() {
-    echo "    Wifi Enable" >> $DEBUGLOG
+    echo "$SCRIPT_NAME: wifi_enable()" >> $DEBUG_LOG
 
     settingsCountry="$(/usr/bin/batocera-settings-get -f "$BATOCONF" wifi.country)"
     [ -n "$settingsCountry" ] && /usr/sbin/iw reg set "$settingsCountry"
         
-    echo "        Country: $settingsCountry" >> $DEBUGLOG
+    echo "$SCRIPT_NAME: wifi_enable(): Country: $settingsCountry" >> $DEBUG_LOG
     
     #  Extra 'enable wifi' to deal with the 'No Carrier' error that can occur on 5Ghz
-    connmanctl enable wifi 2>> $DEBUGLOG
-    sleep 1
-    connmanctl enable wifi 2>> $DEBUGLOG
+    echo "$SCRIPT_NAME: wifi_enable(): '> connmanctl enable wifi'" >> $DEBUG_LOG
+    
+    connmanctl enable wifi 2>> $DEBUG_LOG >> $DEBUG_LOG
     sleep 1
     
+    echo "$SCRIPT_NAME: wifi_enable(): '> connmanctl enable wifi'" >> $DEBUG_LOG
+    
+    connmanctl enable wifi 2>> $DEBUG_LOG >> $DEBUG_LOG
+    sleep 1
+    
+    echo "$SCRIPT_NAME: wifi_enable(): '> connmanctl scan wifi'" >> $DEBUG_LOG
     #  We redirect the output of scan wifi because we need to check for a NO CARRIER error.
-    connmanctl scan wifi > /tmp/connmanctl_scan_wifi.log 2> /tmp/connmanctl_scan_wifi.err
+    connmanctl scan wifi 2> /tmp/connmanctl_scan_wifi.err > /tmp/connmanctl_scan_wifi.log 
+    
+    cat /tmp/connmanctl_scan_wifi.log >> $DEBUG_LOG
+    cat /tmp/connmanctl_scan_wifi.err >> $DEBUG_LOG
+    
     if grep -q "wifi: No carrier" /tmp/connmanctl_scan_wifi.err ; then
-        echo "NO CARRIER:  Restart Daemon" >> $DEBUGLOG
+        echo "$SCRIPT_NAME: wifi_enable(): NO CARRIER:  Restart Daemon" >> $DEBUG_LOG
     fi
     
-    #  This was an attempt to recover from the No Carrier, but it seems that the double
-    #  'enable wifi' above either resolves that problem or greatly reduces its occurence.
-#    for i in `seq 1 $ENABLE_RETRY_COUNT`; do
-#        echo "        Calling 'connmanctl enable wifi'" | tee -a $DEBUGLOG
-#        connmanctl enable wifi 2>> $DEBUGLOG
-#        sleep $DELAY_ENABLE_TO_SCAN
-#        echo "        Calling 'connmanctl scan wifi'" | tee -a $DEBUGLOG
-#        connmanctl scan wifi > /tmp/connmanctl_scan_wifi.log 2> /tmp/connmanctl_scan_wifi.err
-        
-#	cat /tmp/connmanctl_scan_wifi.log >> $DEBUGLOG 2>> $DEBUGLOG
-
-#	if grep -q "wifi: No carrier" /tmp/connmanctl_scan_wifi.err ; then
-#            echo "        No CARRIER ..." | tee -a $DEBUGLOG
-#            echo "        Disabling Wifi ..." | tee -a $DEBUGLOG
-#            connmanctl disable wifi | tee -a $DEBUGLOG
-#            sleep $DELAY_DISABLE_ENABLE
-#	else
-#	    echo "Waiting for connection" | tee -a
-#	    wait_for_connection
-#	    RESULT=$?
-	    
-#	    if [ $? -ne 0 ] ; then
-#	        break
-#	    fi
-#	fi
-#    done
+    echo "$SCRIPT_NAME: wifi_enable(): '> connmanctl technologies'" >> $DEBUG_LOG
+    connmanctl technologies >> $DEBUG_LOG 2>> $DEBUG_LOG
 }
 
 wifi_disable() {
-    echo "    Wifi Disable" | tee -a $DEBUGLOG
-    echo "        Calling 'connmanctl disable wifi'" | tee -a $DEBUGLOG
-    connmanctl disable wifi 2>> $DEBUGLOG
+    echo "$SCRIPT_NAME: wifi_disable():" >> $DEBUG_LOG
+    
+    echo "$SCRIPT_NAME: wifi_disable(): > connmanctl disable wifi" >> $DEBUG_LOG
+    
+    connmanctl disable wifi >> $DEBUG_LOG 2>> $DEBUG_LOG
 }
 
 case "$1" in
     start)
+        echo "$SCRIPT_NAME: start" >> $DEBUG_LOG
+        
         batocera_hostname
         wifi_configure_all
-        printf "Starting connman: "
-        start-stop-daemon -S -q -m -b -p /var/run/connmand.pid --exec /usr/sbin/connmand -- -n -r $DEBUG_MODE
+        
+        echo "$SCRIPT_NAME: start: > start-stop-daemon -S -q -m -b -p /var/run/connmandd.pid --exec /usr/sbin/connmand -- -n -r $DEBUG_MODE" >> $DEBUG_LOG
+        start-stop-daemon -S -q -m -b -p /var/run/connmand.pid --exec /usr/sbin/connmand -- -n -r $DEBUG_MODE  2>> $DEBUG_LOG >> $DEBUG_LOG
 
         sleep 2
         
         for i in $(seq 1 20); do
-            echo "    Calling 'connmanctl state'" | tee -a /tmp/S20connman.log
-            if connmanctl state 2>> $DEBUGLOG | tee -a $DEBUGLOG | grep -qE '^[ ]*State[ ]='; then
+            echo "$SCRIPT_NAME: start > connmanctl state" >> $DEBUG_LOG
+            if connmanctl state 2>> $DEBUG_LOG | tee -a $DEBUG_LOG | grep -qE '^[ ]*State[ ]='; then
                 break
             fi
             sleep 0.25
@@ -196,11 +196,17 @@ case "$1" in
             wifi_disable
         fi
 
+        echo "$SCRIPT_NAME: start: done." >> $DEBUG_LOG
         echo "done."
     ;;
     stop)
+        echo "$SCRIPT_NAME: stop" >> $DEBUG_LOG
         printf "Stopping connman: "
-        start-stop-daemon -K -q -p /var/run/connmand.pid
+        
+        echo "$SCRIPT_NAME: stop: >start-stop-daemon -K -q -p /var/run/connmand.pid" >> $DEBUG_LOG
+        
+        start-stop-daemon -K -q -p /var/run/connmand.pid  2>> $DEBUG_LOG >> $DEBUG_LOG
+        echo "$SCRIPT_NAME: stop: done." >> $DEBUG_LOG
         echo "done."
         ;;
     restart | reload)

--- a/board/batocera/fsoverlay/etc/init.d/S20connman
+++ b/board/batocera/fsoverlay/etc/init.d/S20connman
@@ -3,6 +3,11 @@
 ### choose configuration file
 BATOCONF="/userdata/system/batocera.conf"
 BOOTCONF="/boot/batocera-boot.conf"
+DEBUGLOG=/userdata/system/logs/S20connman.log
+
+#  add -d to DEBUG_MODE to put connman into debug mode, you'll also need to adjust syslog
+#  have connman log to syslog.
+DEBUG_MODE=
 
 # if /userdata is not yet available
 if ! [ -f "$BATOCONF" ]; then
@@ -44,7 +49,6 @@ batocera_hostname() {
 
 # configure wifi files, always
 batocera_wifi_configure() {
-    echo "    Wifi Configure: Device $1" >> /tmp/S20connman.log
     X=$1
 
     settings_hide=false; settings_name="${X}"
@@ -79,43 +83,90 @@ batocera_wifi_configure() {
 }
 
 wifi_configure_all() {
-    echo "    Wifi Configure All" >> /tmp/S20connman.log
+    echo "    Wifi Configure All" >> $DEBUGLOG
 
     for i in 1 2 3 .hidden; do
         batocera_wifi_configure "$i"
     done
 }
 
+max_connection_wait=3
+wait_for_connection() {
+    echo "    Waiting for connection" | tee -a $DEBUGLOG
+    for n in `seq 1 $max_connection_wait`; do
+        echo "    Checking connmanctl state [$n of $max_connection_wait]" | tee -a $DEBUGLOG
+        connmanctl state > /tmp/connmanctl_state.log
+        
+        if grep -q "State = idle" /tmp/connmanctl_state.log ; then
+            echo "        Idle." | tee -a /tmp/S20connman.log
+            cat /tmp/connmanctl_state.log | tee -a $DEBUGLOG
+        else
+            echo "        Not idle" | tee -a /tmp/S20connman.log
+            cat /tmp/connmanctl_state.log | tee -a $DEBUGLOG
+            break
+        fi
+        sleep 1
+    done
+    
+    return 0
+}
+
+# These variables are only needed by the disabled code below
+ENABLE_RETRY_COUNT=1
+DELAY_ENABLE_TO_SCAN=1
 
 wifi_enable() {
-    echo "    Wifi Enable" >> /tmp/S20connman.log
+    echo "    Wifi Enable" >> $DEBUGLOG
 
     settingsCountry="$(/usr/bin/batocera-settings-get -f "$BATOCONF" wifi.country)"
-    echo "        Country: $settingsCountry" >> /tmp/S20connman.log
-
     [ -n "$settingsCountry" ] && /usr/sbin/iw reg set "$settingsCountry"
+        
+    echo "        Country: $settingsCountry" >> $DEBUGLOG
+    
+    #  Extra 'enable wifi' to deal with the 'No Carrier' error that can occur on 5Ghz
+    connmanctl enable wifi 2>> $DEBUGLOG
+    sleep 1
+    connmanctl enable wifi 2>> $DEBUGLOG
+    sleep 1
+    
+    #  We redirect the output of scan wifi because we need to check for a NO CARRIER error.
+    connmanctl scan wifi > /tmp/connmanctl_scan_wifi.log 2> /tmp/connmanctl_scan_wifi.err
+    if grep -q "wifi: No carrier" /tmp/connmanctl_scan_wifi.err ; then
+        echo "NO CARRIER:  Restart Daemon" >> $DEBUGLOG
+    fi
+    
+    #  This was an attempt to recover from the No Carrier, but it seems that the double
+    #  'enable wifi' above either resolves that problem or greatly reduces its occurence.
+#    for i in `seq 1 $ENABLE_RETRY_COUNT`; do
+#        echo "        Calling 'connmanctl enable wifi'" | tee -a $DEBUGLOG
+#        connmanctl enable wifi 2>> $DEBUGLOG
+#        sleep $DELAY_ENABLE_TO_SCAN
+#        echo "        Calling 'connmanctl scan wifi'" | tee -a $DEBUGLOG
+#        connmanctl scan wifi > /tmp/connmanctl_scan_wifi.log 2> /tmp/connmanctl_scan_wifi.err
+        
+#	cat /tmp/connmanctl_scan_wifi.log >> $DEBUGLOG 2>> $DEBUGLOG
 
-
-    for i in { 1..10 }
-    do
-        echo "        Calling 'connmanctl enable wifi'" >> /tmp/S20connman.log
-        connmanctl enable wifi 2>/tmp/S20connman.log
-        echo "        Calling 'connmanctl scan wifi'" >> /tmp/S20connman.log
-        connmanctl scan   wifi 2>/tmp/connmanctl_scan_wifi.log
-	cat /tmp/connmanctl_scan_wifi.log >> /tmp/S20connman.log
-
-	if grep -q "wifi: No carrier" /tmp/connmanctl_scan_wifi.log ; then
-            echo "        No CARRIER.  Retrying ..." >> /tmp/S20connman.log
-	else
-	    break
-	fi
-    done
+#	if grep -q "wifi: No carrier" /tmp/connmanctl_scan_wifi.err ; then
+#            echo "        No CARRIER ..." | tee -a $DEBUGLOG
+#            echo "        Disabling Wifi ..." | tee -a $DEBUGLOG
+#            connmanctl disable wifi | tee -a $DEBUGLOG
+#            sleep $DELAY_DISABLE_ENABLE
+#	else
+#	    echo "Waiting for connection" | tee -a
+#	    wait_for_connection
+#	    RESULT=$?
+	    
+#	    if [ $? -ne 0 ] ; then
+#	        break
+#	    fi
+#	fi
+#    done
 }
 
 wifi_disable() {
-    echo "    Wifi Disable" >> /tmp/S20connman.log
-    echo "        Calling 'connmanctl disable wifi'" >> /tmp/S20connman.log
-    connmanctl disable wifi 2>/tmp/S20connman.log
+    echo "    Wifi Disable" | tee -a $DEBUGLOG
+    echo "        Calling 'connmanctl disable wifi'" | tee -a $DEBUGLOG
+    connmanctl disable wifi 2>> $DEBUGLOG
 }
 
 case "$1" in
@@ -123,12 +174,13 @@ case "$1" in
         batocera_hostname
         wifi_configure_all
         printf "Starting connman: "
-        start-stop-daemon -S -q -m -b -p /var/run/connmand.pid --exec /usr/sbin/connmand -- -n -r
+        start-stop-daemon -S -q -m -b -p /var/run/connmand.pid --exec /usr/sbin/connmand -- -n -r $DEBUG_MODE
 
-
+        sleep 2
+        
         for i in $(seq 1 20); do
-            echo "    Calling 'connmanctl state'" >> /tmp/S20connman.log
-            if connmanctl state 2>/tmp/S20connman.log | tee -a /tmp/S20connman.log | grep -qE '^[ ]*State[ ]='; then
+            echo "    Calling 'connmanctl state'" | tee -a /tmp/S20connman.log
+            if connmanctl state 2>> $DEBUGLOG | tee -a $DEBUGLOG | grep -qE '^[ ]*State[ ]='; then
                 break
             fi
             sleep 0.25
@@ -136,11 +188,11 @@ case "$1" in
         sleep 0.5
 
         if [ "$settingsWlan" = "1" ];then
-            # Detach the wifi enable process
-            echo "    enabling wifi [detached]" >> /tmp/S20connman.log
-            wifi_enable &
+            # Disable WiFi before we enable it.
+            wifi_disable
+            sleep 2
+            wifi_enable
         else
-            echo "    disabling wifi" >> /tmp/S20connman.log
             wifi_disable
         fi
 
@@ -153,7 +205,7 @@ case "$1" in
         ;;
     restart | reload)
         $0 stop
-        sleep 0.5
+        sleep 3
         $0 start
         ;;
     *)

--- a/board/batocera/fsoverlay/etc/init.d/S20connman
+++ b/board/batocera/fsoverlay/etc/init.d/S20connman
@@ -28,8 +28,9 @@ settingsWlan="$(/usr/bin/batocera-settings-get -f "$BATOCONF" wifi.enabled)"
 # lets the user allow for dynamic hostname configuration from DHCP, by
 # setting the system.hostname setting to a blank empty string.
 batocera_hostname() {
-    echo "$(date -u): starting initial hostname configuraton" > /tmp/hostname.log
+    echo "$(date -u): starting initial hostname configuration" > /tmp/hostname.log
     settings_hostname="$(/usr/bin/batocera-settings-get -f "$BATOCONF" system.hostname)"
+
     if [ -n "$settings_hostname" ]; then
         echo "Setting initial hostname from system.hostname: ${settings_hostname}" >> /tmp/hostname.log
         hostname="$settings_hostname"
@@ -43,6 +44,7 @@ batocera_hostname() {
 
 # configure wifi files, always
 batocera_wifi_configure() {
+    echo "    Wifi Configure: Device $1" >> /tmp/S20connman.log
     X=$1
 
     settings_hide=false; settings_name="${X}"
@@ -77,21 +79,43 @@ batocera_wifi_configure() {
 }
 
 wifi_configure_all() {
+    echo "    Wifi Configure All" >> /tmp/S20connman.log
+
     for i in 1 2 3 .hidden; do
         batocera_wifi_configure "$i"
     done
 }
 
+
 wifi_enable() {
+    echo "    Wifi Enable" >> /tmp/S20connman.log
+
     settingsCountry="$(/usr/bin/batocera-settings-get -f "$BATOCONF" wifi.country)"
+    echo "        Country: $settingsCountry" >> /tmp/S20connman.log
+
     [ -n "$settingsCountry" ] && /usr/sbin/iw reg set "$settingsCountry"
 
-    connmanctl enable wifi 2>/dev/null
-    connmanctl scan   wifi 2>/dev/null
+
+    for i in { 1..10 }
+    do
+        echo "        Calling 'connmanctl enable wifi'" >> /tmp/S20connman.log
+        connmanctl enable wifi 2>/tmp/S20connman.log
+        echo "        Calling 'connmanctl scan wifi'" >> /tmp/S20connman.log
+        connmanctl scan   wifi 2>/tmp/connmanctl_scan_wifi.log
+	cat /tmp/connmanctl_scan_wifi.log >> /tmp/S20connman.log
+
+	if grep -q "wifi: No carrier" /tmp/connmanctl_scan_wifi.log ; then
+            echo "        No CARRIER.  Retrying ..." >> /tmp/S20connman.log
+	else
+	    break
+	fi
+    done
 }
 
 wifi_disable() {
-    connmanctl disable wifi 2>/dev/null
+    echo "    Wifi Disable" >> /tmp/S20connman.log
+    echo "        Calling 'connmanctl disable wifi'" >> /tmp/S20connman.log
+    connmanctl disable wifi 2>/tmp/S20connman.log
 }
 
 case "$1" in
@@ -101,8 +125,10 @@ case "$1" in
         printf "Starting connman: "
         start-stop-daemon -S -q -m -b -p /var/run/connmand.pid --exec /usr/sbin/connmand -- -n -r
 
+
         for i in $(seq 1 20); do
-            if connmanctl state 2>/dev/null | grep -qE '^[ ]*State[ ]='; then
+            echo "    Calling 'connmanctl state'" >> /tmp/S20connman.log
+            if connmanctl state 2>/tmp/S20connman.log | tee -a /tmp/S20connman.log | grep -qE '^[ ]*State[ ]='; then
                 break
             fi
             sleep 0.25
@@ -111,8 +137,10 @@ case "$1" in
 
         if [ "$settingsWlan" = "1" ];then
             # Detach the wifi enable process
+            echo "    enabling wifi [detached]" >> /tmp/S20connman.log
             wifi_enable &
         else
+            echo "    disabling wifi" >> /tmp/S20connman.log
             wifi_disable
         fi
 

--- a/board/batocera/fsoverlay/etc/init.d/S20connman
+++ b/board/batocera/fsoverlay/etc/init.d/S20connman
@@ -99,31 +99,6 @@ wifi_configure_all() {
     done
 }
 
-max_connection_wait=3
-wait_for_connection() {
-    echo "    Waiting for connection" | tee -a $DEBUGLOG
-    for n in `seq 1 $max_connection_wait`; do
-        echo "    Checking connmanctl state [$n of $max_connection_wait]" | tee -a $DEBUGLOG
-        connmanctl state > /tmp/connmanctl_state.log
-        
-        if grep -q "State = idle" /tmp/connmanctl_state.log ; then
-            echo "        Idle." | tee -a /tmp/S20connman.log
-            cat /tmp/connmanctl_state.log | tee -a $DEBUGLOG
-        else
-            echo "        Not idle" | tee -a /tmp/S20connman.log
-            cat /tmp/connmanctl_state.log | tee -a $DEBUGLOG
-            break
-        fi
-        sleep 1
-    done
-    
-    return 0
-}
-
-# These variables are only needed by the disabled code below
-ENABLE_RETRY_COUNT=1
-DELAY_ENABLE_TO_SCAN=1
-
 wifi_enable() {
     echo "$SCRIPT_NAME: wifi_enable()" >> $DEBUG_LOG
 
@@ -131,18 +106,11 @@ wifi_enable() {
     [ -n "$settingsCountry" ] && /usr/sbin/iw reg set "$settingsCountry"
         
     echo "$SCRIPT_NAME: wifi_enable(): Country: $settingsCountry" >> $DEBUG_LOG
-    
-    #  Extra 'enable wifi' to deal with the 'No Carrier' error that can occur on 5Ghz
+
     echo "$SCRIPT_NAME: wifi_enable(): '> connmanctl enable wifi'" >> $DEBUG_LOG
     
     connmanctl enable wifi 2>> $DEBUG_LOG >> $DEBUG_LOG
-    sleep 1
-    
-    echo "$SCRIPT_NAME: wifi_enable(): '> connmanctl enable wifi'" >> $DEBUG_LOG
-    
-    connmanctl enable wifi 2>> $DEBUG_LOG >> $DEBUG_LOG
-    sleep 1
-    
+   
     echo "$SCRIPT_NAME: wifi_enable(): '> connmanctl scan wifi'" >> $DEBUG_LOG
     #  We redirect the output of scan wifi because we need to check for a NO CARRIER error.
     connmanctl scan wifi 2> /tmp/connmanctl_scan_wifi.err > /tmp/connmanctl_scan_wifi.log 
@@ -151,7 +119,7 @@ wifi_enable() {
     cat /tmp/connmanctl_scan_wifi.err >> $DEBUG_LOG
     
     if grep -q "wifi: No carrier" /tmp/connmanctl_scan_wifi.err ; then
-        echo "$SCRIPT_NAME: wifi_enable(): NO CARRIER:  Restart Daemon" >> $DEBUG_LOG
+        echo "$SCRIPT_NAME: wifi_enable(): NO CARRIER" >> $DEBUG_LOG
     fi
     
     echo "$SCRIPT_NAME: wifi_enable(): '> connmanctl technologies'" >> $DEBUG_LOG
@@ -175,8 +143,6 @@ case "$1" in
         
         echo "$SCRIPT_NAME: start: > start-stop-daemon -S -q -m -b -p /var/run/connmandd.pid --exec /usr/sbin/connmand -- -n -r $DEBUG_MODE" >> $DEBUG_LOG
         start-stop-daemon -S -q -m -b -p /var/run/connmand.pid --exec /usr/sbin/connmand -- -n -r $DEBUG_MODE  2>> $DEBUG_LOG >> $DEBUG_LOG
-
-        sleep 2
         
         for i in $(seq 1 20); do
             echo "$SCRIPT_NAME: start > connmanctl state" >> $DEBUG_LOG
@@ -188,10 +154,7 @@ case "$1" in
         sleep 0.5
 
         if [ "$settingsWlan" = "1" ];then
-            # Disable WiFi before we enable it.
-            wifi_disable
-            sleep 2
-            wifi_enable
+            wifi_enable &
         else
             wifi_disable
         fi
@@ -211,7 +174,7 @@ case "$1" in
         ;;
     restart | reload)
         $0 stop
-        sleep 3
+        sleep 0.5
         $0 start
         ;;
     *)

--- a/board/batocera/fsoverlay/etc/init.d/S20connman
+++ b/board/batocera/fsoverlay/etc/init.d/S20connman
@@ -154,6 +154,7 @@ case "$1" in
         sleep 0.5
 
         if [ "$settingsWlan" = "1" ];then
+            # Detach the wifi enable process
             wifi_enable &
         else
             wifi_disable


### PR DESCRIPTION
S20connman now logs to /userdata/logs/S20connman

Some notes
- There is still an error that sometimes gets reported that is not captured and logged but shows on STDOUT

Known Issues:
- S20connman restart is not actually reliable as it does not wait long enough between the start and stop calls.  For more reliability, we should add logic to have it wait for a shutdown.  If S20connman restart does not automatically connect, calling S20connman start is sufficient to have it work.