### PR TITLE
es-theme-knulli 2.4.x (from 1.9.2)

### DIFF
--- a/package/batocera/emulationstation/es-theme-knulli/es-theme-knulli.mk
+++ b/package/batocera/emulationstation/es-theme-knulli/es-theme-knulli.mk
@@ -3,8 +3,8 @@
 # EmulationStation theme "Knulli"
 #
 ################################################################################
-# Version: Commits on December 18, 2024
-ES_THEME_KNULLI_VERSION = b611122d467be992935066b833a6d6976dcff7d8
+# Version: Commits on December 20, 2024
+ES_THEME_KNULLI_VERSION = 475530aa189a07937a7a312ca3fb713cc2353f65
 ES_THEME_KNULLI_SITE = $(call github,symbuzzer,es-theme-knulli,$(ES_THEME_KNULLI_VERSION))
 
 define ES_THEME_KNULLI_INSTALL_TARGET_CMDS


### PR DESCRIPTION
# v2.4.x
- Fixed knulli splashscreen asset

# v2.3.x
- Added region options for system logos
- Changed default game list to Detailed_2 (from Grid)
- Fixed some variabled due make things more understandable
- Added missing Recording and Sega System SP logo
- Removed unnecassary background images
- Theme options categorized
- Switched to new versioning system

# v2.2.0
- Added new detailed_2 view
- Added disable video option for all gamelist views
- Added disable system animations and reflection option
- Added missing aleck64 and alice32 system logos
- Fixed splash screen image resolutions for different sceen sizes
- Removed Rocknix releated things
- Fixed code structure on some xml files

# v2.1.0
- Added show or hide system logo on game lists

# v2.0.0
- Added game count on console selection screen. (Can be enabled and disabled from theme setting, default disabled)
- Added new Anbernic colorscheme and splashscreen (Can be selected from theme setting)
- Detailed view redesigned
- Synced gamelist font size for all views
- Simplified font variables
- Removed unnecessary strings