### PR TITLE
h700: Add melondsds to es_systems_nds.cfg.

### DIFF
--- a/board/batocera/allwinner/h700/fsoverlay/usr/share/emulationstation/es_systems_nds.cfg
+++ b/board/batocera/allwinner/h700/fsoverlay/usr/share/emulationstation/es_systems_nds.cfg
@@ -25,6 +25,7 @@
             <emulator name="libretro">
                 <cores>
                     <core>melonds</core>
+                    <core>melondsds</core>
                 </cores>
             </emulator>
         </emulators>


### PR DESCRIPTION
Fixes issue where melondsds core was installed but not selectable from emulationstation.