### PR TITLE
Quick Resume Mode - Supporting Changes

### DIFF
--- a/board/batocera/fsoverlay/usr/bin/knulli-shutdown
+++ b/board/batocera/fsoverlay/usr/bin/knulli-shutdown
@@ -1,15 +1,8 @@
 #!/bin/sh
 
-check_ingame() {
-    HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" "http://localhost:1234/runningGame")
-
-    if [ "$HTTP_STATUS" -eq 201 ]; then
-        # Game is not running
-        return 1
-    else
-        return 0
-    fi
-}
+# These shouldn't change but are configurable
+IN_GAME_FLAG=/var/run/in-game.flag
+SHUTDOWN_FLAG=/var/run/shutdown.flag
 
 do_poweroff() {
     POWEROFF=$1
@@ -18,11 +11,14 @@ do_poweroff() {
     batocera-brightness dispoff
     amixer set Master mute
 
-    if check_ingame; then
-        touch /var/run/shutdown-ingame.flag
+    # Create our flag file indicating a shutdown has been commenced
+    touch $SHUTDOWN_FLAG
+
+    if [ -f $IN_GAME_FLAG ]; then
+        echo "in-game=1" >> $SHUTDOWN_FLAG
         batocera-es-swissknife --emukill # Exits an emulator if one is running and is needed for auto save state on exit.
     else
-        touch /var/run/shutdown-normal.flag
+        echo "in-game=0" >> $SHUTDOWN_FLAG
     fi
 
     if [ "$POWEROFF" = "reboot" ]; then
@@ -32,6 +28,7 @@ do_poweroff() {
         mount -o remount,ro /boot
         reboot
     else
+
         sync
 
         # Start a background process that waits for a timeout duration before forcing shutdown
@@ -64,3 +61,4 @@ case "$1" in
 esac
 
 exit 0
+

--- a/package/batocera/core/batocera-userdatainit/datainit/system/scripts/knulli_game_events.sh
+++ b/package/batocera/core/batocera-userdatainit/datainit/system/scripts/knulli_game_events.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+LOG_FILE=/userdata/system/logs/knulli-game-events.log
+IN_GAME_FLAG=/var/run/in-game.flag
+
+# Ensure the log file exists
+[ ! -f "$LOG_FILE" ] && touch "$LOG_FILE"
+
+echo "$(date '+%Y-%m-%d %H:%M:%S'): knulli_game_events.sh beginning executing" && echo >> $LOG_FILE
+echo "The following parameters were passed to this script: $*" >> $LOG_FILE
+
+# Case selection for first parameter parsed, our event.
+case $1 in
+    gameStart)
+        # Commands in here will be executed on the start of any game.
+        touch "$IN_GAME_FLAG"
+        echo "$(date '+%Y-%m-%d %H:%M:%S'): Created in-game.flag..." >> $LOG_FILE
+    ;;
+    gameStop)
+        # Commands in here will be executed on the stop of any game.
+        rm -f "$IN_GAME_FLAG"
+        echo "$(date '+%Y-%m-%d %H:%M:%S'): Removed in-game.flag..." >> $LOG_FILE
+    ;;
+esac
+
+echo "$(date '+%Y-%m-%d %H:%M:%S'): knulli_game_events.sh completed execution." >> $LOG_FILE


### PR DESCRIPTION
Refactored `knulli-shutdown` to decouple requirement on web API `runningGame` endpoint, which is not available when launching game on boot. Added `knulli-game-events.sh` to `package/batocera/core/batocera-userdatainit` for management of `in_game.flag` required for Quick Resume feature / shutdown script.

Even though the script was added to `batocera-userdatainit` it is not ending up in my build. Must investigate further.