### PR TITLE
/etc/init.d/rcS: Run S00bootcustom serially.

### DIFF
--- a/board/batocera/allwinner/a133/fsoverlay/etc/init.d/rcS
+++ b/board/batocera/allwinner/a133/fsoverlay/etc/init.d/rcS
@@ -30,7 +30,7 @@ for i in /etc/init.d/S??* ; do
             ;;
         *)
             case "$i" in
-                *S01dbus | *S02resize | *S03modules | *S04populate | *S05udev | *S06audio | *S06modprobe | *S11share | *S12populateshare) # Don't run these in background
+                *S00bootcustom | *S01dbus | *S02resize | *S03modules | *S04populate | *S05udev | *S06audio | *S06modprobe | *S11share | *S12populateshare) # Don't run these in background
                     $i start
                     ;;
                 *)

--- a/board/batocera/allwinner/h700/fsoverlay/etc/init.d/rcS
+++ b/board/batocera/allwinner/h700/fsoverlay/etc/init.d/rcS
@@ -49,7 +49,7 @@ for i in /etc/init.d/S??* ; do
             ;;
         *)
             case "$i" in
-                *S01dbus | *S02resize | *S03modules | *S04populate | *S05udev | *S06audio | *S06modprobe | *S11share | *S12populateshare) # Don't run these in background
+                *S00bootcustom | *S01dbus | *S02resize | *S03modules | *S04populate | *S05udev | *S06audio | *S06modprobe | *S11share | *S12populateshare) # Don't run these in background
                     $i start
                     ;;
                 *)

--- a/board/batocera/allwinner/r16/miyoo-a30/fsoverlay/etc/init.d/rcS
+++ b/board/batocera/allwinner/r16/miyoo-a30/fsoverlay/etc/init.d/rcS
@@ -38,7 +38,7 @@ for i in /etc/init.d/S??* ; do
             ;;
         *)
             case "$i" in
-                *S02resize | *S05udev | *S06audio | *S11share | *S12populateshare) # Don't run these in background
+                *S00bootcustom | *S02resize | *S05udev | *S06audio | *S11share | *S12populateshare) # Don't run these in background
                     $i start
                     ;;
                 *)

--- a/board/batocera/qualcomm/sm8250/fsoverlay/etc/init.d/rcS
+++ b/board/batocera/qualcomm/sm8250/fsoverlay/etc/init.d/rcS
@@ -38,7 +38,7 @@ for i in /etc/init.d/S??* ; do
             ;;
         *)
             case "$i" in
-                *S01dbus | *S02resize | *S03modules | *S04populate | *S05udev | *S06audio | *S06modprobe | *S11share | *S12populateshare) # Don't run these in background
+                *S00bootcustom | *S01dbus | *S02resize | *S03modules | *S04populate | *S05udev | *S06audio | *S06modprobe | *S11share | *S12populateshare) # Don't run these in background
                     $i start
                     ;;
                 *)

--- a/board/batocera/rockchip/rk3128/fsoverlay/etc/init.d/rcS
+++ b/board/batocera/rockchip/rk3128/fsoverlay/etc/init.d/rcS
@@ -25,7 +25,7 @@ for i in /etc/init.d/S??* ; do
             ;;
         *)
             case "$i" in
-                *S02resize | *S05udev | *S06audio | *S11share | *S12populateshare) # Don't run these in background
+                *S00bootcustom | *S02resize | *S05udev | *S06audio | *S11share | *S12populateshare) # Don't run these in background
                     $i start
                     ;;
                 *)


### PR DESCRIPTION
S00bootcustom, which executes the user-provided /boot/boot-custom.sh during early boot, must not run in the background should the user want to reliably hook later init.d scripts.