### PR TITLE
a133: Add audio.headphone setting to control ALSA volume.

### DIFF
--- a/board/batocera/allwinner/a133/fsoverlay/etc/init.d/S27audioconfig
+++ b/board/batocera/allwinner/a133/fsoverlay/etc/init.d/S27audioconfig
@@ -107,7 +107,7 @@ case "$1" in
  	start)
 		start_audioconfig
 		amixer -c 0 sset HpSpeaker on
-		amixer -c 0 set 'Headphone' 0
+		amixer -c 0 sset Headphone "$(batocera-settings-get audio.headphone || echo 0)"
 	;;
  	stop)
 		stop_audioconfig

--- a/board/batocera/allwinner/a133/fsoverlay/etc/init.d/S31emulationstation
+++ b/board/batocera/allwinner/a133/fsoverlay/etc/init.d/S31emulationstation
@@ -13,7 +13,6 @@ case "$1" in
 		    exit 1
 		fi
 		emulationstation-standalone &
-		amixer -c 0 set 'Headphone' 0
 	    fi
 	    ;;
 

--- a/board/batocera/allwinner/a133/fsoverlay/usr/bin/batocera-audio
+++ b/board/batocera/allwinner/a133/fsoverlay/usr/bin/batocera-audio
@@ -39,9 +39,10 @@ case "${ACTION}" in
         MODE="$2"
         case "${MODE}" in
             auto)
-                   MODE=alsa_output._sys_devices_platform_soc_sndcodec_sound_card0.stereo-fallback
+                   MODE=alsa_output._sys_devices_platform_soc_sndcodec_sound_card0.playback.0.0
                    LANG=C pactl set-default-sink "${MODE}" || exit 1
-                   amixer -c 0 sset Headphone 0
+                   amixer -c 0 sset HpSpeaker on
+                   amixer -c 0 sset Headphone "$(batocera-settings-get audio.headphone || echo 0)"
 		   ;;
        	    *)
                 LANG=C pactl set-default-sink "${MODE}" || exit 1


### PR DESCRIPTION
When I use headphones on my TrimUI Brick the volume is quite loud.  I have to reduce it to 20% or lower to make it comfortable, but with the software volume control that results in poor quality (bit-crushed) audio.

I've found that if I set the ALSA "Headphone" volume level to a mid-range value (say 5 instead of the max 0) then I get a much more usable range of software volume control and the audio quality is improved.

Given the circumstances around the TrimUI hardware volume control, I think it makes sense to allow users to manually set a value for that in batocera.conf (audio.headphone) if they need to, and default to the current max (0) value otherwise.