### PR TITLE
Set viewport bias for RA 1.20.x compatibility

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroConfig.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroConfig.py
@@ -1238,6 +1238,9 @@ def writeBezelConfig(generator: Generator, bezel: str | None, shaderBezel: bool,
     retroarchConfig['input_overlay_enable'] = "false"
     retroarchConfig['video_message_pos_x']  = 0.05
     retroarchConfig['video_message_pos_y']  = 0.05
+    # Set default video viewport bias in case no bezel can be applied
+    retroarchConfig['video_viewport_bias_x']  = 0.500000
+    retroarchConfig['video_viewport_bias_y']  = 0.500000
 
     # special text...
     if bezel == "none" or bezel == "":
@@ -1352,6 +1355,10 @@ def writeBezelConfig(generator: Generator, bezel: str | None, shaderBezel: bool,
         infos["messagey"] = 0.0
 
     retroarchConfig['input_overlay_opacity'] = infos["opacity"]
+    
+    # Set video viewport bias for viewport positioning
+    retroarchConfig['video_viewport_bias_x']  = 0.000000
+    retroarchConfig['video_viewport_bias_y']  = 1.000000
 
     # stretch option
     if system.isOptSet('bezel_stretch') and system.getOptBoolean('bezel_stretch') == True:


### PR DESCRIPTION
Now this was fun. 🙄

`video_viewport_bias_x` and `video_viewport_bias_y` are, apparently, two new RA settings to give people a headache. They are set to `0.5` by default but need to be set to `0.0` and `1.0` for absolute positioning of the game underneath the overlays when dealing with Batocera bezels.

Tested with Earthworm Jim on SNES on **RG34XX** with built-in display and on a regular 16:9 4K TV via HDMI with
* Bezel set `default-knulli`
* Bezel set `ambiance_monitor_1084s`
* Bezel set `none`

(And yes, my version of `default-knulli` already has a SNES bezel for the RG34XX.)