### PR TITLE
Fix the interactions between batocera-shaders and slang-shaders for P…

### DIFF
--- a/package/batocera/emulators/retroarch/shaders/batocera-shaders/batocera-shaders.mk
+++ b/package/batocera/emulators/retroarch/shaders/batocera-shaders/batocera-shaders.mk
@@ -71,16 +71,4 @@ define BATOCERA_SHADERS_INSTALL_TARGET_CMDS
 	done
 endef
 
-define BATOCERA_SHADERS_SLANG
-    # Some shaders got the .slan(g) variants moved
-    cd $(TARGET_DIR)/usr/share/batocera/shaders/ && cp -f pixel-art-scaling/sharp-bilinear-simple.slangp ./interpolation/ && \
-		cp -f pixel-art-scaling/shaders/sharp-bilinear-simple.slang ./interpolation/shaders/
-    cd $(TARGET_DIR)/usr/share/batocera/shaders/ && cp -f edge-smoothing/scalehq/2xScaleHQ.slangp ./scalehq/ && \
-		cp -f ./edge-smoothing/scalehq/shaders/2xScaleHQ.slang ./scalehq/shaders/
-endef
-
-ifeq ($(BR2_PACKAGE_SLANG_SHADERS),y)
-    BATOCERA_SHADERS_POST_INSTALL_TARGET_HOOKS = BATOCERA_SHADERS_SLANG
-endif
-
 $(eval $(generic-package))

--- a/package/batocera/emulators/retroarch/shaders/slang-shaders/slang-shaders.mk
+++ b/package/batocera/emulators/retroarch/shaders/slang-shaders/slang-shaders.mk
@@ -21,4 +21,18 @@ define SLANG_SHADERS_INSTALL_TARGET_CMDS
 	    INSTALLDIR=$(TARGET_DIR)/usr/share/batocera/shaders install
 endef
 
+define SLANG_SHADERS_BATOCERA_SHADERS_SLANG
+    # Some shaders got the .slan(g) variants moved
+    mkdir -p $(TARGET_DIR)/usr/share/batocera/shaders/interpolation/shaders
+    mkdir -p $(TARGET_DIR)/usr/share/batocera/shaders/scalehq/shaders
+    cd $(TARGET_DIR)/usr/share/batocera/shaders/ && cp -f pixel-art-scaling/sharp-bilinear-simple.slangp ./interpolation/ && \
+		cp -f pixel-art-scaling/shaders/sharp-bilinear-simple.slang ./interpolation/shaders/
+    cd $(TARGET_DIR)/usr/share/batocera/shaders/ && cp -f edge-smoothing/scalehq/2xScaleHQ.slangp ./scalehq/ && \
+		cp -f ./edge-smoothing/scalehq/shaders/2xScaleHQ.slang ./scalehq/shaders/
+endef
+
+ifeq ($(BR2_PACKAGE_BATOCERA_SHADERS),y)
+    SLANG_SHADERS_POST_INSTALL_TARGET_HOOKS = SLANG_SHADERS_BATOCERA_SHADERS_SLANG
+endif
+
 $(eval $(generic-package))


### PR DESCRIPTION
My build last night failed [here](https://github.com/knulli-cfw/distribution/blob/8215ae6f28aeb57e69ce6eee8eb512ea9e6d74e9/package/batocera/emulators/retroarch/shaders/batocera-shaders/batocera-shaders.mk#L76) since it was trying to build batocera-shaders before slang-shaders.  I checked upstream and they had already committed this fix for it.