### PR TITLE
a133, h700: batocera-brightness: Enforce XMIN when decreasing brightn…

### DIFF
--- a/board/batocera/allwinner/a133/fsoverlay/usr/bin/batocera-brightness
+++ b/board/batocera/allwinner/a133/fsoverlay/usr/bin/batocera-brightness
@@ -65,7 +65,7 @@ then
 
         NEWVAL=$(expr "${X}" "-" "${DELTA}")
 
-        if [ "${NEWVAL}" -le 0 ] && [ "${X}" -ne "${XMIN}" ] && [ "${X}" -ne 0 ]; then
+        if [ "${NEWVAL}" -lt "${XMIN}" ] && [ "${X}" -ne "${XMIN}" ] && [ "${X}" -ne 0 ]; then
             NEWVAL=${XMIN}
         fi
     fi

--- a/board/batocera/allwinner/h700/fsoverlay/usr/bin/batocera-brightness
+++ b/board/batocera/allwinner/h700/fsoverlay/usr/bin/batocera-brightness
@@ -83,7 +83,7 @@ then
 
         NEWVAL=$(expr "${X}" "-" "${DELTA}")
 
-        if [ "${NEWVAL}" -le 0 ] && [ "${X}" -ne "${XMIN}" ] && [ "${X}" -ne 0 ]; then
+        if [ "${NEWVAL}" -lt "${XMIN}" ] && [ "${X}" -ne "${XMIN}" ] && [ "${X}" -ne 0 ]; then
             NEWVAL=${XMIN}
         fi
     fi


### PR DESCRIPTION
So I found that with certain starting brightness values, if I kept decreasing screen brightness it would eventually increase before turning off. 

Here's the behavior reproduced in a terminal:
```
[root@KNULLI /userdata/system]# batocera-brightness 10
Brightness set to: 25
[root@KNULLI /userdata/system]# batocera-brightness - 5
Brightness set to: 13
[root@KNULLI /userdata/system]# batocera-brightness - 5
Brightness set to: 1
[root@KNULLI /userdata/system]# batocera-brightness - 5
Brightness set to: 3
```

The fix here is to clamp the calculated brightness values in the range (0,XMIN) to XMIN, which in this case makes it go straight from 13 to 3.