### PR TITLE
a133: Fix display brightness on boot.

### DIFF
--- a/board/batocera/allwinner/a133/fsoverlay/usr/bin/batocera-brightness
+++ b/board/batocera/allwinner/a133/fsoverlay/usr/bin/batocera-brightness
@@ -26,6 +26,20 @@ cycle() {
     exit 0
 }
 
+display_off() {
+    echo disable > /sys/kernel/debug/dispdbg/command
+    echo lcd0 > /sys/kernel/debug/dispdbg/name
+    echo 1 > /sys/kernel/debug/dispdbg/start
+    exit 0
+}
+
+display_on() {
+    echo enable > /sys/kernel/debug/dispdbg/command
+    echo lcd0 > /sys/kernel/debug/dispdbg/name
+    echo 1 > /sys/kernel/debug/dispdbg/start
+    exit 0
+}
+
 # get
 if test $# = 0
 then
@@ -39,7 +53,11 @@ fi
 if test $# = 1
 then
     if [ "${1}" = "cycle" ]; then
-       cycle
+        cycle
+    elif [ "${1}" = "dispoff" ]; then
+        display_off
+    elif [ "${1}" = "dispon" ]; then
+        display_on
     else
        NEWVAL=$(expr "${1}" "*" "${XMAX}" / 100)
        setValue "${NEWVAL}" "${XMAX}"

--- a/board/batocera/allwinner/a133/fsoverlay/usr/bin/batocera-brightness
+++ b/board/batocera/allwinner/a133/fsoverlay/usr/bin/batocera-brightness
@@ -1,9 +1,20 @@
 #!/bin/sh
 
+# Stored brightness value when the display is turned off.
+VALPATH=/var/run/$(basename "$0")
+
 XMAX=255
 XMIN=3
 
 CYCLESTEP=20 # % additional brightbess at each step
+
+getValue() {
+    if [ -e "${VALPATH}" ]; then
+        cat "${VALPATH}"
+    else
+        brightness get
+    fi
+}
 
 setValue() {
     NEWVAL=$1
@@ -11,11 +22,15 @@ setValue() {
     test "${NEWVAL}" -lt 0         && NEWVAL=0
     test "${NEWVAL}" -gt "${XMAX}" && NEWVAL="${XMAX}"
 
-    brightness set "${NEWVAL}"
+    if [ -e "${VALPATH}" ]; then
+        echo "${NEWVAL}" > "${VALPATH}"
+    else
+        brightness set "${NEWVAL}"
+    fi
 }
 
 cycle() {
-    X=$(brightness get)
+    X=$(getValue)
     FVALUE=$(echo "scale=3;${X}" "*" "100" / "${XMAX}" | bc)
     LC_ALL=C FVALUE=$(printf '%.*f\n' 0 "${FVALUE}") # round
     NEWVAL=$(echo "${FVALUE} + ${CYCLESTEP}" | bc)
@@ -27,23 +42,25 @@ cycle() {
 }
 
 display_off() {
-    echo disable > /sys/kernel/debug/dispdbg/command
-    echo lcd0 > /sys/kernel/debug/dispdbg/name
-    echo 1 > /sys/kernel/debug/dispdbg/start
+    if [ ! -e "${VALPATH}" ]; then
+        brightness get > "${VALPATH}"
+        brightness set 0
+    fi
     exit 0
 }
 
 display_on() {
-    echo enable > /sys/kernel/debug/dispdbg/command
-    echo lcd0 > /sys/kernel/debug/dispdbg/name
-    echo 1 > /sys/kernel/debug/dispdbg/start
+    if [ -e "${VALPATH}" ]; then
+        brightness set "$(cat "${VALPATH}")"
+        rm -f "${VALPATH}"
+    fi
     exit 0
 }
 
 # get
 if test $# = 0
 then
-    X=$(brightness get)
+    X=$(getValue)
     FVALUE=$(echo "scale=3;${X}" "*" "100" / "${XMAX}" | bc)
     LC_ALL=C printf '%.*f\n' 0 "${FVALUE}" # round
     exit 0
@@ -68,7 +85,7 @@ fi
 # set +/-
 if test $# = 2
 then
-    X=$(brightness get)
+    X=$(getValue)
     DELTA=$(expr "${2}" '*' ${XMAX} / 100)
 
     if [ "${1}" = "+" ]; then

--- a/board/batocera/allwinner/a133/fsoverlay/usr/bin/power-button
+++ b/board/batocera/allwinner/a133/fsoverlay/usr/bin/power-button
@@ -21,9 +21,7 @@ suspend_system() {
 }
 
 shutdown_system() {
-    echo disable > /sys/kernel/debug/dispdbg/command
-    echo lcd0 > /sys/kernel/debug/dispdbg/name
-    echo 1 > /sys/kernel/debug/dispdbg/start
+    batocera-brightness dispoff
     amixer set Master mute
     batocera-es-swissknife --emukill
     knulli-shutdown -s


### PR DESCRIPTION
When you boot on a133 the display brightness is always set to the minimum.  This is due to 3df81aeefd9327ef6c4c71a28a0c439aec081be6, which turns the display off before shutdown, resulting in /etc/init.d/S27brightness saving "display.brightness=0" to batocera.conf. 

This adds proper dispoff/dispon support to a133 batocera-brightness.  In doing so, it makes sure to preserve the display-on brightness value so that the proper value is written by S27brightness on shutdown.