### PR TITLE
a133: Fix NTP on TrimUI Brick/Smart Pro.

### DIFF
--- a/board/batocera/allwinner/a133/fsoverlay/etc/init.d/S49ntp
+++ b/board/batocera/allwinner/a133/fsoverlay/etc/init.d/S49ntp
@@ -1,0 +1,56 @@
+#!/bin/sh
+#
+# Starts Network Time Protocol daemon
+#
+
+DAEMON="ntpd"
+PIDFILE="/var/run/$DAEMON.pid"
+
+NTPD_ARGS="-u ntp:ntp -g"
+
+# shellcheck source=/dev/null
+[ -r "/etc/default/$DAEMON" ] && . "/etc/default/$DAEMON"
+
+start() {
+	printf 'Starting %s: ' "$DAEMON"
+	# shellcheck disable=SC2086 # we need the word splitting
+	start-stop-daemon -S -q -p "$PIDFILE" -x "/usr/sbin/$DAEMON" \
+		-- $NTPD_ARGS -p "$PIDFILE"
+	status=$?
+	if [ "$status" -eq 0 ]; then
+		echo "OK"
+	else
+		echo "FAIL"
+	fi
+	return "$status"
+}
+
+stop() {
+	printf 'Stopping %s: ' "$DAEMON"
+	start-stop-daemon -K -q -p "$PIDFILE"
+	status=$?
+	if [ "$status" -eq 0 ]; then
+		rm -f "$PIDFILE"
+		echo "OK"
+	else
+		echo "FAIL"
+	fi
+	return "$status"
+}
+
+restart() {
+	stop
+	sleep 1
+	start
+}
+
+case "$1" in
+	start|stop|restart)
+		"$1";;
+	reload)
+		# Restart, since there is no true "reload" feature.
+		restart;;
+	*)
+		echo "Usage: $0 {start|stop|restart|reload}"
+		exit 1
+esac

--- a/board/batocera/allwinner/a133/fsoverlay/etc/init.d/S49ntp
+++ b/board/batocera/allwinner/a133/fsoverlay/etc/init.d/S49ntp
@@ -14,8 +14,10 @@ NTPD_ARGS="-u ntp:ntp -g"
 start() {
 	printf 'Starting %s: ' "$DAEMON"
 	# shellcheck disable=SC2086 # we need the word splitting
+	# sh -c: Automatically restart ntpd on failure.
 	start-stop-daemon -S -q -p "$PIDFILE" -x "/usr/sbin/$DAEMON" \
-		-- $NTPD_ARGS -p "$PIDFILE"
+		-ba /bin/sh -- -c 'while :; do "$0" "$@" && exit; sleep 1; done' \
+		"/usr/sbin/$DAEMON" $NTPD_ARGS -np "$PIDFILE"
 	status=$?
 	if [ "$status" -eq 0 ]; then
 		echo "OK"


### PR DESCRIPTION
This fixes the long-standing issue on TrimUI Brick/Smart Pro whereby ntpd dies before it can set time from a network time source, resulting in large clock drift or a clock that's never been set properly to begin with.

What's happening here is that, on boot, ntpd creates and binds sockets to port 123 on each network interface.  However since there's no link on the wlan0 interface, ntpd doesn't bind to it, but it does track and dynamically bind to interfaces when they come up later.  However, when the wlan0 interface comes up on the a133 kernel, ntpd logs this error and exits:

```
socket(AF_INET, SOCK_DGRAM, 0) failed on address [redacted]: Permission denied
unexpected socket() error Permission denied code 13 (not EPROTONOSUPPORT nor EAFNOSUPPORT nor EPFNOSUPPORT) - exiting
```

Really this error shouldn't be happening.  Linux doesn't require any special capabilities to _create_ a socket (although it may to actually bind it), and this error doesn't happen when running the same version/configuration of ntpd on the h700 kernel.  So I have to assume this is a bug in the a133 kernel.

Fortunately the workaround here is straightforward--simply restarting ntpd _after_ the wlan0 link comes up allows ntpd to create and bind a socket to it just fine.  The only remaining issue is that start-stop-daemon doesn't support automatic restarts.

Ultimately, the fix here is to modify S49ntp to run a small shell script that loop restarts ntpd on failure.  Normal termination (SIGTERM) of ntpd works as expected.