### PR TITLE
es-theme-knulli updated to v3.2.x

### DIFF
--- a/package/knulli/themes/es-theme-knulli/es-theme-knulli.mk
+++ b/package/knulli/themes/es-theme-knulli/es-theme-knulli.mk
@@ -3,8 +3,8 @@
 # EmulationStation theme "Knulli"
 #
 ################################################################################
-# Version: Commits on February 16, 2025
-ES_THEME_KNULLI_VERSION = ffe723fd493c0adece99b109fd134485c8c5daaf
+# Version: Commits on February 17, 2025
+ES_THEME_KNULLI_VERSION = 860e8c0f564c59e56faf0618473eeae264c39bf8
 ES_THEME_KNULLI_SITE = $(call github,symbuzzer,es-theme-knulli,$(ES_THEME_KNULLI_VERSION))
 
 define ES_THEME_KNULLI_INSTALL_TARGET_CMDS

--- a/package/knulli/themes/es-theme-knulli/es-theme-knulli.mk
+++ b/package/knulli/themes/es-theme-knulli/es-theme-knulli.mk
@@ -3,8 +3,8 @@
 # EmulationStation theme "Knulli"
 #
 ################################################################################
-# Version: Commits on January 29, 2025
-ES_THEME_KNULLI_VERSION = 21813407a6e5137fc8868c97067d5e31a981c35e
+# Version: Commits on February 07, 2025
+ES_THEME_KNULLI_VERSION = 9527b3150a813a746d8ecad0329dcd93ad75a4ba
 ES_THEME_KNULLI_SITE = $(call github,symbuzzer,es-theme-knulli,$(ES_THEME_KNULLI_VERSION))
 
 define ES_THEME_KNULLI_INSTALL_TARGET_CMDS

--- a/package/knulli/themes/es-theme-knulli/es-theme-knulli.mk
+++ b/package/knulli/themes/es-theme-knulli/es-theme-knulli.mk
@@ -3,8 +3,8 @@
 # EmulationStation theme "Knulli"
 #
 ################################################################################
-# Version: Commits on February 15, 2025
-ES_THEME_KNULLI_VERSION = 1a26fe86399e4f418a539b0c3b720dda65a24506
+# Version: Commits on February 16, 2025
+ES_THEME_KNULLI_VERSION = ffe723fd493c0adece99b109fd134485c8c5daaf
 ES_THEME_KNULLI_SITE = $(call github,symbuzzer,es-theme-knulli,$(ES_THEME_KNULLI_VERSION))
 
 define ES_THEME_KNULLI_INSTALL_TARGET_CMDS

--- a/package/knulli/themes/es-theme-knulli/es-theme-knulli.mk
+++ b/package/knulli/themes/es-theme-knulli/es-theme-knulli.mk
@@ -3,8 +3,8 @@
 # EmulationStation theme "Knulli"
 #
 ################################################################################
-# Version: Commits on February 07, 2025
-ES_THEME_KNULLI_VERSION = 9527b3150a813a746d8ecad0329dcd93ad75a4ba
+# Version: Commits on February 15, 2025
+ES_THEME_KNULLI_VERSION = 1a26fe86399e4f418a539b0c3b720dda65a24506
 ES_THEME_KNULLI_SITE = $(call github,symbuzzer,es-theme-knulli,$(ES_THEME_KNULLI_VERSION))
 
 define ES_THEME_KNULLI_INSTALL_TARGET_CMDS


### PR DESCRIPTION
# v3.2.x
- Added Trimui splash and colorset
- Fixed some strings
- Simplified theme strings
- Updated all translates with new theme strings
- Added theme author's github to version info

# v3.1.x
- Added Miyoo splash and colorset

# v3.0.x
- Added Rocknix and Powkiddy splashes and colorsets
- System and Grid scroll type settings are separated
- Added reflection effect to system view again
- Added rating stars to detailed view
- Removed some unused strings from all language files
- Removed vertical wheel scroll type due a lot of conflicts

# v2.19.x
- Changed 32X and GameGear system logos for different regions
- Updated Turkish translation
- Re-designed some theme settings items