### PR TITLE
h700: /etc/init.d/rcS: Don't boot if lid is closed (rg35xx-sp).

### DIFF
--- a/board/batocera/allwinner/h700/fsoverlay/etc/init.d/rcS
+++ b/board/batocera/allwinner/h700/fsoverlay/etc/init.d/rcS
@@ -4,8 +4,9 @@
 # using the sdl-compat/SDL2 for rendering
 insmod /lib/modules/mali_kbase.ko
 
-# Rotate screen for the rg28xx
 BOARD=$(cat /boot/boot/batocera.board)
+
+# Rotate screen for the rg28xx
 if [ "$BOARD" = "rg28xx" ]; then
     fbset -g 480 640 480 1280 32
 fi
@@ -22,6 +23,12 @@ if [ "$RESTART_FLAG" = "1" ]; then
 else
     # Call the charger process
     /usr/bin/charger
+fi
+
+if [ "$BOARD" = "rg35xx-sp" ]; then
+    # Don't proceed with boot if lid is closed.
+    LIDSW=/sys/class/power_supply/axp2202-battery/hallkey
+    [ "$(cat "$LIDSW")" = 0 ] && exec knulli-shutdown -s
 fi
 
 # Start the progress bar


### PR DESCRIPTION
Partially intended as a workaround for #287, but more generally addresses the issue of accidentally powering on while the lid is closed.  See `/etc/pm/sleep.d/99-postresume-sp` for similar behavior on resume with lid closed.