### PR TITLE
a133: Fix Avahi on TrimUI Brick/Smart Pro.

### DIFF
--- a/board/batocera/allwinner/a133/fsoverlay/etc/init.d/S50avahi-daemon
+++ b/board/batocera/allwinner/a133/fsoverlay/etc/init.d/S50avahi-daemon
@@ -1,0 +1,20 @@
+#!/bin/sh
+#
+# avahi-daemon init script
+
+DAEMON=/usr/sbin/avahi-daemon
+case "$1" in
+    start)
+	$DAEMON -c || $DAEMON -D
+	;;
+    stop)
+	$DAEMON -c && $DAEMON -k
+	;;
+    reload)
+	$DAEMON -c && $DAEMON -r
+	;;
+    *)
+	echo "Usage: S50avahi-daemon {start|stop|reload}" >&2
+	exit 1
+	;;
+esac

--- a/board/batocera/allwinner/a133/fsoverlay/etc/init.d/S50avahi-daemon
+++ b/board/batocera/allwinner/a133/fsoverlay/etc/init.d/S50avahi-daemon
@@ -5,7 +5,7 @@
 DAEMON=/usr/sbin/avahi-daemon
 case "$1" in
     start)
-	$DAEMON -c || $DAEMON -D
+	$DAEMON -c || $DAEMON -D --no-drop-root
 	;;
     stop)
 	$DAEMON -c && $DAEMON -k


### PR DESCRIPTION
Similar to https://github.com/knulli-cfw/buildroot/pull/5, on TrimUI Brick/Smart Pro avahi-daemon is unable to open sockets after dropping root privileges:
```
[root@KNULLI /userdata/system]# avahi-daemon
Found user 'avahi' (UID 100) and group 'avahi' (GID 101).
Successfully dropped root privileges.
avahi-daemon 0.8 starting up.
WARNING: No NSS support for mDNS detected, consider installing nss-mdns!
Successfully called chroot().
Successfully dropped remaining capabilities.
No service file found in /etc/avahi/services.
socket() failed: Permission denied
socket() failed: Permission denied
Failed to create server: No suitable network protocol available
avahi-daemon 0.8 exiting.
```
As with ntpd, this is due to a bug in the a133 kernel whereby it incorrectly requires the CAP_NET_RAW capability to create any AF_INET sockets (not just SOCK_RAW ones as the name implies).  Fortunately avahi-daemon provides a --no-drop-root option, which works as advertised:
```
[root@KNULLI /userdata/system]# avahi-daemon --no-drop-root
avahi-daemon 0.8 starting up.
WARNING: No NSS support for mDNS detected, consider installing nss-mdns!
No service file found in /etc/avahi/services.
Joining mDNS multicast group on interface wlan0.IPv6 with address [redacted].
New relevant interface wlan0.IPv6 for mDNS.
Joining mDNS multicast group on interface wlan0.IPv4 with address [redacted].
New relevant interface wlan0.IPv4 for mDNS.
Joining mDNS multicast group on interface lo.IPv6 with address ::1.
New relevant interface lo.IPv6 for mDNS.
Joining mDNS multicast group on interface lo.IPv4 with address 127.0.0.1.
New relevant interface lo.IPv4 for mDNS.
Network interface enumeration completed.
Registering new address record for [redacted] on wlan0.*.
Registering new address record for [redacted] on wlan0.IPv4.
Registering new address record for ::1 on lo.*.
Registering new address record for 127.0.0.1 on lo.IPv4.
Server startup complete. Host name is KNULLI.local. Local service cookie is 3088896966.
```