### PR TITLE
Added exception handling in hotkeygen on read pid

### DIFF
--- a/package/batocera/utils/hotkeygen/hotkeygen.py
+++ b/package/batocera/utils/hotkeygen/hotkeygen.py
@@ -285,8 +285,11 @@ def do_new_context(context_name: str | None = None, context_json: str | None = N
             GCONTEXT_FILE.unlink()
 
     # inform the process
-    pid = int(read_pid())
-    os.kill(pid, signal.SIGHUP)
+    try:
+        pid = int(read_pid())
+        os.kill(pid, signal.SIGHUP)
+    except (ValueError, FileNotFoundError, IOError):
+        pass # No PID file or it could not be read or parsed, no signal needed
 
 
 def do_list() -> None:


### PR DESCRIPTION
Hotkeygen crashes when it tries to signal the daemon when it is not running. This caused MelonDS DS to fail on startup:

`Traceback (most recent call last):
  File "/usr/bin/hotkeygen", line 456, in <module>
    do_new_context(new_context_name, new_context_json)
  File "/usr/bin/hotkeygen", line 288, in do_new_context
    pid = int(read_pid())
              ^^^^^^^^^^
  File "/usr/bin/hotkeygen", line 272, in read_pid
    with GPID_FILE.open() as fd:
         ^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/pathlib.py", line 1044, in open
    return io.open(self, mode, buffering, encoding, errors, newline)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
FileNotFoundError: [Errno 2] No such file or directory: '/var/run/hotkeygen.pid' `

Caught the exception to prevent this crash.