### PR TITLE
knulli-a133.board: Use zstd for root squashfs.

### DIFF
--- a/configs/knulli-a133.board
+++ b/configs/knulli-a133.board
@@ -10,7 +10,7 @@ BR2_TARGET_OPTIMIZATION="-pipe -fsigned-char -mcpu=cortex-a53 -mtune=cortex-a53"
 BR2_TARGET_GENERIC_GETTY_BAUDRATE_115200=y
 BR2_GLOBAL_PATCH_DIR="$(BR2_EXTERNAL_BATOCERA_PATH)/board/batocera/patches $(BR2_EXTERNAL_BATOCERA_PATH)/board/batocera/allwinner/patches $(BR2_EXTERNAL_BATOCERA_PATH)/board/batocera/allwinner/a133/patches"
 BR2_ROOTFS_OVERLAY="$(BR2_EXTERNAL_BATOCERA_PATH)/board/batocera/fsoverlay $(BR2_EXTERNAL_BATOCERA_PATH)/board/batocera/allwinner/a133/fsoverlay"
-BR2_TARGET_ROOTFS_SQUASHFS4_GZIP=y
+BR2_TARGET_ROOTFS_SQUASHFS4_ZSTD=y
 
 # batocera splash screen
 #BR2_PACKAGE_BATOCERA_SPLASH_MPV=y

--- a/configs/knulli-a133_defconfig
+++ b/configs/knulli-a133_defconfig
@@ -125,7 +125,7 @@ BR2_TARGET_OPTIMIZATION="-pipe -fsigned-char -mcpu=cortex-a53 -mtune=cortex-a53"
 BR2_TARGET_GENERIC_GETTY_BAUDRATE_115200=y
 BR2_GLOBAL_PATCH_DIR="$(BR2_EXTERNAL_BATOCERA_PATH)/board/batocera/patches $(BR2_EXTERNAL_BATOCERA_PATH)/board/batocera/allwinner/patches $(BR2_EXTERNAL_BATOCERA_PATH)/board/batocera/allwinner/a133/patches"
 BR2_ROOTFS_OVERLAY="$(BR2_EXTERNAL_BATOCERA_PATH)/board/batocera/fsoverlay $(BR2_EXTERNAL_BATOCERA_PATH)/board/batocera/allwinner/a133/fsoverlay"
-BR2_TARGET_ROOTFS_SQUASHFS4_GZIP=y
+BR2_TARGET_ROOTFS_SQUASHFS4_ZSTD=y
 
 # batocera splash screen
 #BR2_PACKAGE_BATOCERA_SPLASH_MPV=y


### PR DESCRIPTION
The a133 kernel supports zstd-compressed squashfs volumes.  With faster and better compression (ratios) than gzip, why not use it?