### PR TITLE
Introduced a capability check command

### DIFF
--- a/board/batocera/allwinner/a133/fsoverlay/etc/pm/sleep.d/99-postresume-jsled
+++ b/board/batocera/allwinner/a133/fsoverlay/etc/pm/sleep.d/99-postresume-jsled
@@ -1,8 +1,7 @@
 #!/bin/bash
 
-BOARD=$(cat /boot/boot/batocera.board)
-# We only want the script to run for these devices
-if [ "$BOARD" != "rg40xx-h" ] && [ "$BOARD" != "rg40xx-v" ] && [ "$BOARD" != "rg-cubexx" ] && [ "$BOARD" != "trimui-smart-pro" ] && [ "$BOARD" != "trimui-brick" ]; then
+# We only want to run the script if the board has RGB capability
+if ! knulli-board-capability "rgb"; then
     exit 1
 fi
 

--- a/board/batocera/allwinner/a133/fsoverlay/etc/pm/sleep.d/99-postresume-sp
+++ b/board/batocera/allwinner/a133/fsoverlay/etc/pm/sleep.d/99-postresume-sp
@@ -1,8 +1,7 @@
 #!/bin/bash
 
-# Auto-resumes sleep if resume while lid is closed only for sp
-BOARD=$(cat /boot/boot/batocera.board)
-if [ "$BOARD" != "rg35xx-sp" ]; then
+# We only want to run the script if the board has lid capability
+if ! knulli-board-capability "lid"; then
     exit 1
 fi
 

--- a/board/batocera/allwinner/a133/fsoverlay/usr/bin/dpad-toggle
+++ b/board/batocera/allwinner/a133/fsoverlay/usr/bin/dpad-toggle
@@ -1,8 +1,7 @@
 #!/bin/bash
 
-BOARD=$(cat /boot/boot/batocera.board)
-# We don't want the script to run for these devices
-if [ "$BOARD" = "rg40xx-h" ] || [ "$BOARD" = "rg40xx-v" ] || [ "$BOARD" = "rg35xx-h" ] || [ "$BOARD" = "rg-cubexx" ]; then
+# We only want to run the script if the board has no analog stick capability
+if knulli-board-capability "analogstick"; then
     exit 1
 fi
 

--- a/board/batocera/allwinner/a133/fsoverlay/usr/share/batocera/services/lid_shutdown
+++ b/board/batocera/allwinner/a133/fsoverlay/usr/share/batocera/services/lid_shutdown
@@ -1,8 +1,7 @@
 #!/bin/bash
 
-BOARD=$(cat /boot/boot/batocera.board)
-# We only want the script to run for rg35xx-sp
-if [ "$BOARD" != "rg35xx-sp" ]; then
+# We only want to run the script if the board has lid capability
+if ! knulli-board-capability "lid"; then
     exit 1
 fi
 

--- a/board/batocera/allwinner/h700/fsoverlay/etc/pm/sleep.d/99-postresume-jsled
+++ b/board/batocera/allwinner/h700/fsoverlay/etc/pm/sleep.d/99-postresume-jsled
@@ -1,8 +1,7 @@
 #!/bin/bash
 
-BOARD=$(cat /boot/boot/batocera.board)
-# We only want the script to run for these devices
-if [ "$BOARD" != "rg40xx-h" ] && [ "$BOARD" != "rg40xx-v" ] && [ "$BOARD" != "rg-cubexx" ] && [ "$BOARD" != "trimui-smart-pro" ] && [ "$BOARD" != "trimui-brick" ]; then
+# We only want to run the script if the board has RGB capability
+if ! knulli-board-capability "rgb"; then
     exit 1
 fi
 

--- a/board/batocera/allwinner/h700/fsoverlay/etc/pm/sleep.d/99-postresume-sp
+++ b/board/batocera/allwinner/h700/fsoverlay/etc/pm/sleep.d/99-postresume-sp
@@ -1,8 +1,7 @@
 #!/bin/bash
 
-# Auto-resumes sleep if resume while lid is closed only for sp
-BOARD=$(cat /boot/boot/batocera.board)
-if [ "$BOARD" != "rg35xx-sp" ]; then
+# We only want to run the script if the board has lid capability
+if ! knulli-board-capability "lid"; then
     exit 1
 fi
 

--- a/board/batocera/allwinner/h700/fsoverlay/usr/bin/dpad-toggle
+++ b/board/batocera/allwinner/h700/fsoverlay/usr/bin/dpad-toggle
@@ -1,8 +1,7 @@
 #!/bin/bash
 
-BOARD=$(cat /boot/boot/batocera.board)
-# We don't want the script to run for these devices
-if [ "$BOARD" = "rg40xx-h" ] || [ "$BOARD" = "rg40xx-v" ] || [ "$BOARD" = "rg35xx-h" ] || [ "$BOARD" = "rg-cubexx" ]; then
+# We only want to run the script if the board has no analog stick capability
+if knulli-board-capability "analogstick"; then
     exit 1
 fi
 

--- a/board/batocera/allwinner/h700/fsoverlay/usr/bin/knulli-rgb-led
+++ b/board/batocera/allwinner/h700/fsoverlay/usr/bin/knulli-rgb-led
@@ -1,8 +1,7 @@
 #!/bin/bash
 
-BOARD=$(cat /boot/boot/batocera.board)
-# We only want the script to run for these devices
-if [ "$BOARD" != "rg40xx-h" ] && [ "$BOARD" != "rg40xx-v" ] && [ "$BOARD" != "rg-cubexx" ]; then
+# We only want to run the script if the board has RGB capability
+if ! knulli-board-capability "rgb"; then
     exit 1
 fi
 

--- a/board/batocera/allwinner/h700/fsoverlay/usr/bin/lid-control
+++ b/board/batocera/allwinner/h700/fsoverlay/usr/bin/lid-control
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-BOARD=$(cat /boot/boot/batocera.board)
-if [ "$BOARD" != "rg35xx-sp" ]; then
+# We only want to run the script if the board has lid capability
+if ! knulli-board-capability "lid"; then
     exit 1
 fi
 

--- a/board/batocera/allwinner/r16/miyoo-a30/fsoverlay/usr/share/batocera/services/lid_shutdown
+++ b/board/batocera/allwinner/r16/miyoo-a30/fsoverlay/usr/share/batocera/services/lid_shutdown
@@ -1,8 +1,7 @@
 #!/bin/bash
 
-BOARD=$(cat /boot/boot/batocera.board)
-# We only want the script to run for rg35xx-sp
-if [ "$BOARD" != "rg35xx-sp" ]; then
+# We only want to run the script if the board has lid capability
+if ! knulli-board-capability "lid"; then
     exit 1
 fi
 

--- a/board/batocera/fsoverlay/etc/init.d/S28rgbled
+++ b/board/batocera/fsoverlay/etc/init.d/S28rgbled
@@ -1,8 +1,7 @@
 #!/bin/bash
 
-BOARD=$(cat /boot/boot/batocera.board)
-# We only want the script to run for these devices
-if [ "$BOARD" != "rg40xx-h" ] && [ "$BOARD" != "rg40xx-v" ] && [ "$BOARD" != "rg-cubexx" ] && [ "$BOARD" != "trimui-smart-pro" ] && [ "$BOARD" != "trimui-brick" ]; then
+# We only want to run the script if the board has RGB capability
+if ! knulli-board-capability "rgb"; then
     exit 1
 fi
 

--- a/board/batocera/fsoverlay/usr/bin/knulli-board-capability
+++ b/board/batocera/fsoverlay/usr/bin/knulli-board-capability
@@ -9,7 +9,7 @@ HAS_CAPABILITY=false
 CAPABILITY=$1
 
 if [ -z "$CAPABILITY" ]; then
-    echo "Usage: $0 <rgb|lid|hdmi|wifi|bluetooth|adb|analogstick>"
+    echo "Usage: $0 <rgb|lid|hdmi|wifi|bluetooth|analogstick>"
     exit 1
 fi
 
@@ -42,10 +42,6 @@ checkCapabilityByBoard() {
         fi
     elif [ "$CAPABILITY" = "bluetooth" ]; then
         if [ "$BOARD" = "rg35xx-plus" ] || [ "$BOARD" = "rg35xx-h" ] || [ "$BOARD" = "rg35xx-sp" ] || [ "$BOARD" = "rg40xx-h" ] || [ "$BOARD" = "rg40xx-v" ] || [ "$BOARD" = "rg-cubexx" ] || [ "$BOARD" = "trimui-smart-pro" ] || [ "$BOARD" = "trimui-brick" ]; then
-            HAS_CAPABILITY=true
-        fi
-    elif [ "$CAPABILITY" = "adb" ]; then
-        if [ "$BOARD" = "rg35xx-plus" ] || [ "$BOARD" = "rg35xx-h" ] || [ "$BOARD" = "rg35xx-2024" ] || [ "$BOARD" = "rg35xx-sp" ] || [ "$BOARD" = "rg28xx" ] || [ "$BOARD" = "rg40xx-h" ] || [ "$BOARD" = "rg40xx-v" ] || [ "$BOARD" = "rg-cubexx" ] || [ "$BOARD" = "trimui-smart-pro" ] || [ "$BOARD" = "trimui-brick" ]; then
             HAS_CAPABILITY=true
         fi
     elif [ "$CAPABILITY" = "analogstick" ]; then

--- a/board/batocera/fsoverlay/usr/bin/knulli-board-capability
+++ b/board/batocera/fsoverlay/usr/bin/knulli-board-capability
@@ -9,7 +9,7 @@ HAS_CAPABILITY=false
 CAPABILITY=$1
 
 if [ -z "$CAPABILITY" ]; then
-    echo "Usage: $0 <rgb|lid|hdmi|wifi|bluetooth|adb>"
+    echo "Usage: $0 <rgb|lid|hdmi|wifi|bluetooth|adb|analogstick>"
     exit 1
 fi
 
@@ -46,6 +46,10 @@ checkCapabilityByBoard() {
         fi
     elif [ "$CAPABILITY" = "adb" ]; then
         if [ "$BOARD" = "rg35xx-plus" ] || [ "$BOARD" = "rg35xx-h" ] || [ "$BOARD" = "rg35xx-2024" ] || [ "$BOARD" = "rg35xx-sp" ] || [ "$BOARD" = "rg28xx" ] || [ "$BOARD" = "rg40xx-h" ] || [ "$BOARD" = "rg40xx-v" ] || [ "$BOARD" = "rg-cubexx" ] || [ "$BOARD" = "trimui-smart-pro" ] || [ "$BOARD" = "trimui-brick" ]; then
+            HAS_CAPABILITY=true
+        fi
+    elif [ "$CAPABILITY" = "analogstick" ]; then
+        if [ "$BOARD" = "rg35xx-h" ] || [ "$BOARD" = "rg40xx-h" ] || [ "$BOARD" = "rg40xx-v" ] || [ "$BOARD" = "rg-cubexx" ] || [ "$BOARD" = "trimui-brick" ]; then
             HAS_CAPABILITY=true
         fi
     fi

--- a/board/batocera/fsoverlay/usr/bin/knulli-board-capability
+++ b/board/batocera/fsoverlay/usr/bin/knulli-board-capability
@@ -1,0 +1,71 @@
+#!/bin/sh
+
+
+CAPABILITIES_FILE="/boot/boot/batocera.board.capability"
+BOARD_FILE="/boot/boot/batocera.board"
+
+HAS_CAPABILITY=false
+
+CAPABILITY=$1
+
+if [ -z "$CAPABILITY" ]; then
+    echo "Usage: $0 <rgb|lid|hdmi|wifi|bluetooth|adb>"
+    exit 1
+fi
+
+# Examine capability file to check if the board has the given capability.
+checkCapabilityFile() {
+    CAPABILITIES=$(cat $CAPABILITIES_FILE)
+    if echo "$CAPABILITIES" | grep -q "$CAPABILITY"; then
+        HAS_CAPABILITY=true
+    fi
+}
+
+# Read board file and determine hard-coded capabilities by board name.
+checkCapabilityByBoard() {
+    BOARD=$(cat $BOARD_FILE)
+    if [ "$CAPABILITY" = "rgb" ]; then
+        if [ "$BOARD" = "rg40xx-h" ] || [ "$BOARD" = "rg40xx-v" ] || [ "$BOARD" = "rg-cubexx" ] || [ "$BOARD" = "trimui-smart-pro" ] || [ "$BOARD" = "trimui-brick" ]; then
+            HAS_CAPABILITY=true
+        fi
+    elif [ "$CAPABILITY" = "hdmi" ]; then
+        if [ "$BOARD" = "rg35xx-plus" ] || [ "$BOARD" = "rg35xx-h" ] || [ "$BOARD" = "rg35xx-2024" ] || [ "$BOARD" = "rg35xx-sp" ] || [ "$BOARD" = "rg28xx" ] || [ "$BOARD" = "rg40xx-h" ] || [ "$BOARD" = "rg40xx-v" ] || [ "$BOARD" = "rg-cubexx" ]; then
+            HAS_CAPABILITY=true
+        fi
+    elif [ "$CAPABILITY" = "lid" ]; then
+        if [ "$BOARD" = "rg35xx-sp" ]; then
+            HAS_CAPABILITY=true
+        fi
+    elif [ "$CAPABILITY" = "wifi" ]; then
+        if [ "$BOARD" = "rg35xx-plus" ] || [ "$BOARD" = "rg35xx-h" ] || [ "$BOARD" = "rg35xx-sp" ] || [ "$BOARD" = "rg40xx-h" ] || [ "$BOARD" = "rg40xx-v" ] || [ "$BOARD" = "rg-cubexx" ] || [ "$BOARD" = "trimui-smart-pro" ] || [ "$BOARD" = "trimui-brick" ]; then
+            HAS_CAPABILITY=true
+        fi
+    elif [ "$CAPABILITY" = "bluetooth" ]; then
+        if [ "$BOARD" = "rg35xx-plus" ] || [ "$BOARD" = "rg35xx-h" ] || [ "$BOARD" = "rg35xx-sp" ] || [ "$BOARD" = "rg40xx-h" ] || [ "$BOARD" = "rg40xx-v" ] || [ "$BOARD" = "rg-cubexx" ] || [ "$BOARD" = "trimui-smart-pro" ] || [ "$BOARD" = "trimui-brick" ]; then
+            HAS_CAPABILITY=true
+        fi
+    elif [ "$CAPABILITY" = "adb" ]; then
+        if [ "$BOARD" = "rg35xx-plus" ] || [ "$BOARD" = "rg35xx-h" ] || [ "$BOARD" = "rg35xx-2024" ] || [ "$BOARD" = "rg35xx-sp" ] || [ "$BOARD" = "rg28xx" ] || [ "$BOARD" = "rg40xx-h" ] || [ "$BOARD" = "rg40xx-v" ] || [ "$BOARD" = "rg-cubexx" ] || [ "$BOARD" = "trimui-smart-pro" ] || [ "$BOARD" = "trimui-brick" ]; then
+            HAS_CAPABILITY=true
+        fi
+    fi
+
+}
+
+if [ -f $CAPABILITIES_FILE ]; then
+    # If a capabilities file exists, check for the capability
+    # inside the capabilities file.
+    checkCapabilityFile
+else
+    # If capabilities file does not exists, check for the
+    # capability by board name.
+    checkCapabilityByBoard
+fi
+
+if $HAS_CAPABILITY; then
+    echo "true"
+    exit 0
+else
+    echo "false"
+    exit 1
+fi

--- a/board/batocera/fsoverlay/usr/bin/knulli-board-capability
+++ b/board/batocera/fsoverlay/usr/bin/knulli-board-capability
@@ -29,7 +29,7 @@ checkCapabilityByBoard() {
             HAS_CAPABILITY=true
         fi
     elif [ "$CAPABILITY" = "hdmi" ]; then
-        if [ "$BOARD" = "rg35xx-plus" ] || [ "$BOARD" = "rg35xx-h" ] || [ "$BOARD" = "rg35xx-2024" ] || [ "$BOARD" = "rg35xx-sp" ] || [ "$BOARD" = "rg28xx" ] || [ "$BOARD" = "rg40xx-h" ] || [ "$BOARD" = "rg40xx-v" ] || [ "$BOARD" = "rg-cubexx" ]; then
+        if [ "$BOARD" = "rg35xx-plus" ] || [ "$BOARD" = "rg35xx-h" ] || [ "$BOARD" = "rg35xx-2024" ] || [ "$BOARD" = "rg35xx-sp" ] || [ "$BOARD" = "rg28xx" ] || [ "$BOARD" = "rg40xx-h" ] || [ "$BOARD" = "rg40xx-v" ] || [ "$BOARD" = "rg-cubexx" ] || [ "$BOARD" = "rg34xx" ]; then
             HAS_CAPABILITY=true
         fi
     elif [ "$CAPABILITY" = "lid" ]; then
@@ -37,11 +37,11 @@ checkCapabilityByBoard() {
             HAS_CAPABILITY=true
         fi
     elif [ "$CAPABILITY" = "wifi" ]; then
-        if [ "$BOARD" = "rg35xx-plus" ] || [ "$BOARD" = "rg35xx-h" ] || [ "$BOARD" = "rg35xx-sp" ] || [ "$BOARD" = "rg40xx-h" ] || [ "$BOARD" = "rg40xx-v" ] || [ "$BOARD" = "rg-cubexx" ] || [ "$BOARD" = "trimui-smart-pro" ] || [ "$BOARD" = "trimui-brick" ]; then
+        if [ "$BOARD" = "rg35xx-plus" ] || [ "$BOARD" = "rg35xx-h" ] || [ "$BOARD" = "rg35xx-sp" ] || [ "$BOARD" = "rg40xx-h" ] || [ "$BOARD" = "rg40xx-v" ] || [ "$BOARD" = "rg-cubexx" ] || [ "$BOARD" = "rg34xx" ] || [ "$BOARD" = "trimui-smart-pro" ] || [ "$BOARD" = "trimui-brick" ]; then
             HAS_CAPABILITY=true
         fi
     elif [ "$CAPABILITY" = "bluetooth" ]; then
-        if [ "$BOARD" = "rg35xx-plus" ] || [ "$BOARD" = "rg35xx-h" ] || [ "$BOARD" = "rg35xx-sp" ] || [ "$BOARD" = "rg40xx-h" ] || [ "$BOARD" = "rg40xx-v" ] || [ "$BOARD" = "rg-cubexx" ] || [ "$BOARD" = "trimui-smart-pro" ] || [ "$BOARD" = "trimui-brick" ]; then
+        if [ "$BOARD" = "rg35xx-plus" ] || [ "$BOARD" = "rg35xx-h" ] || [ "$BOARD" = "rg35xx-sp" ] || [ "$BOARD" = "rg40xx-h" ] || [ "$BOARD" = "rg40xx-v" ] || [ "$BOARD" = "rg-cubexx" ] || [ "$BOARD" = "rg34xx" ] || [ "$BOARD" = "trimui-smart-pro" ] || [ "$BOARD" = "trimui-brick" ]; then
             HAS_CAPABILITY=true
         fi
     elif [ "$CAPABILITY" = "analogstick" ]; then

--- a/board/batocera/fsoverlay/usr/bin/knulli-rgb-led-daemon
+++ b/board/batocera/fsoverlay/usr/bin/knulli-rgb-led-daemon
@@ -1,8 +1,7 @@
 #!/bin/bash
 
-BOARD=$(cat /boot/boot/batocera.board)
-# We only want the script to run for these devices
-if [ "$BOARD" != "rg40xx-h" ] && [ "$BOARD" != "rg40xx-v" ] && [ "$BOARD" != "rg-cubexx" ] && [ "$BOARD" != "trimui-smart-pro" ] && [ "$BOARD" != "trimui-brick" ]; then
+# We only want to run the script if the board has RGB capability
+if ! knulli-board-capability "rgb"; then
     exit 1
 fi
 

--- a/board/batocera/fsoverlay/usr/share/emulationstation/scripts/achievements/led.sh
+++ b/board/batocera/fsoverlay/usr/share/emulationstation/scripts/achievements/led.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
 
-BOARD=$(cat /boot/boot/batocera.board)
-# We only want the script to run for these devices
-if [ "$BOARD" != "rg40xx-h" ] && [ "$BOARD" != "rg40xx-v" ] && [ "$BOARD" != "rg-cubexx" ] && [ "$BOARD" != "trimui-smart-pro" ] && [ "$BOARD" != "trimui-brick" ]; then
+# We only want to run the script if the board has RGB capability
+if ! knulli-board-capability "rgb"; then
     exit 1
 fi
 

--- a/board/batocera/qualcomm/sm8250/fsoverlay/etc/pm/sleep.d/99-postresume-jsled
+++ b/board/batocera/qualcomm/sm8250/fsoverlay/etc/pm/sleep.d/99-postresume-jsled
@@ -1,8 +1,7 @@
 #!/bin/bash
 
-BOARD=$(cat /boot/boot/batocera.board)
-# We only want the script to run for these devices
-if [ "$BOARD" != "rg40xx-h" ] && [ "$BOARD" != "rg40xx-v" ] && [ "$BOARD" != "rg-cubexx" ] && [ "$BOARD" != "trimui-smart-pro" ] && [ "$BOARD" != "trimui-brick" ]; then
+# We only want to run the script if the board has RGB capability
+if ! knulli-board-capability "rgb"; then
     exit 1
 fi
 

--- a/board/batocera/qualcomm/sm8250/fsoverlay/etc/pm/sleep.d/99-postresume-sp
+++ b/board/batocera/qualcomm/sm8250/fsoverlay/etc/pm/sleep.d/99-postresume-sp
@@ -1,8 +1,7 @@
 #!/bin/bash
 
-# Auto-resumes sleep if resume while lid is closed only for sp
-BOARD=$(cat /boot/boot/batocera.board)
-if [ "$BOARD" != "rg35xx-sp" ]; then
+# We only want to run the script if the board has lid capability
+if ! knulli-board-capability "lid"; then
     exit 1
 fi
 

--- a/board/batocera/qualcomm/sm8250/fsoverlay/usr/share/batocera/services/lid_shutdown
+++ b/board/batocera/qualcomm/sm8250/fsoverlay/usr/share/batocera/services/lid_shutdown
@@ -1,8 +1,7 @@
 #!/bin/bash
 
-BOARD=$(cat /boot/boot/batocera.board)
-# We only want the script to run for rg35xx-sp
-if [ "$BOARD" != "rg35xx-sp" ]; then
+# We only want to run the script if the board has lid capability
+if ! knulli-board-capability "lid"; then
     exit 1
 fi
 

--- a/board/batocera/rockchip/rk3566/fsoverlay/usr/share/batocera/services/lid_shutdown
+++ b/board/batocera/rockchip/rk3566/fsoverlay/usr/share/batocera/services/lid_shutdown
@@ -1,8 +1,7 @@
 #!/bin/bash
 
-BOARD=$(cat /boot/boot/batocera.board)
-# We only want the script to run for rg35xx-sp
-if [ "$BOARD" != "rg35xx-sp" ]; then
+# We only want to run the script if the board has RGB capability
+if ! knulli-board-capability "lid"; then
     exit 1
 fi
 


### PR DESCRIPTION
# Summary

I replaced some board checks with a capability check. **Please review carefully** and make sure that I replaced board checks **correctly**, make sure that I did not accidentally break logic, e.g. by using or missing `!` characters.

# Capability check

I introduced a new command called `knulli-board-capability` which can be called with a single string argument which represents a capability. `knulli-board-capability` echos `true` and returns exit code `0` (success) if the board of the current device has the given capability, otherwise it echos `false` and returns exit code `1 (failure)`.

Known capabilities are:
* `rgb` - device has RGB LEDs (relevant for ES and RGB scripts)
* `lid` - device has a lid (relevant for ES and sleep/shutdown scripts)
* `hdmi` - device has HDMI out (currently unused)
* `wifi` - device has Wi-Fi (currently unused)
* `bluetooth` - device supports Bluetooth (currently unused)
* `analogstick` - device has at least one analog stick (relevant for dpad-as-stick toggles)

The above examples are included in the **hard coded fallback**. However, you can add **any string** to the **capability file** and check for said string via `knulli-board-capability`.

# Capability file

The code implements two different ways of checking capability: If a file `/boot/boot/batocera.board.capability` exists, the file will be read and checked for the given capability strings. Any character may be used as separator, however, I propose that we simply use a space character (` `).

# Hard coded capabilities

Since capability files do not exist in Knulli builds, yet, a fallback mechanism employs board checks to verify if the device has a given feature. I consider this mechanism a **fallback** which we might actually remove once the capability files are established. Until then, the hard-coded fallback helps to 