### PR TITLE
Fix for standalone scummvm detection

### DIFF
--- a/board/batocera/fsoverlay/usr/bin/knulli-detect-scummvm-game
+++ b/board/batocera/fsoverlay/usr/bin/knulli-detect-scummvm-game
@@ -2,7 +2,7 @@
 
 # ScummVM ini file locations
 LIBRETRO_SCUMMVM_INI="/userdata/bios/scummvm.ini"
-STANDALONE_SCUMMVM_INI="/userdata/system/.config/scummvm/scummvm.ini"
+STANDALONE_SCUMMVM_INI="/userdata/system/configs/scummvm/scummvm.ini"
 
 if [ ! -f "$LIBRETRO_SCUMMVM_INI" ]; then
   echo "$LIBRETRO_SCUMMVM_INI missing - creating file."

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/scummvm/scummvmGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/scummvm/scummvmGenerator.py
@@ -49,11 +49,18 @@ class ScummVMGenerator(Generator):
           # rom is a directory: must contains a <game name>.scummvm file
           romPath = rom_path
           romName = next(rom_path.glob("*.scummvm")).stem
-        else:
+        elif rom_path.stat().st_size == 0:
+          # Legacy Batocera ScummVM file (game ID as name)
           # rom is a file: split in directory and file name
           romPath = rom_path.parent
           # Get rom name without extension
           romName = rom_path.stem
+        else:
+          # Knulli auto-generated ScummVM file with target inside:
+          # Split into directory and file content (target)
+          romName = Path(rom_path).read_text()
+          romName = romName.replace('\r', '').replace('\n', '').replace(' ', '')
+          romPath = rom_path.parent
 
         # pad number
         nplayer = 1


### PR DESCRIPTION
* Fixed wrong path to `scummvm.ini` of standalone ScummVM
* Extended configgen script for standalone ScummVM to **optionally** read target/game ID from **inside** the `.scummvm` file if file size is bigger than `0`