### PR TITLE
Fix for TrimUI Brick dpad toggle

### DIFF
--- a/board/batocera/allwinner/a133/fsoverlay/etc/triggerhappy/triggers.d/multimedia_keys.conf
+++ b/board/batocera/allwinner/a133/fsoverlay/etc/triggerhappy/triggers.d/multimedia_keys.conf
@@ -10,3 +10,5 @@ KEY_POWER+BTN_MODE 1          /usr/bin/poweroff.sh
 KEY_POWER 1                  /usr/bin/power-button
 KEY_POWER 0                  /usr/bin/power-button-release
 BTN_START+BTN_SELECT 1       batocera-screenshot
+BTN_SELECT+BTN_MODE 1        /usr/bin/dpad-toggle
+KEY_POWER+BTN_MODE 1         /usr/bin/power-led

--- a/board/batocera/allwinner/a133/fsoverlay/etc/triggerhappy/triggers.d/multimedia_keys.conf
+++ b/board/batocera/allwinner/a133/fsoverlay/etc/triggerhappy/triggers.d/multimedia_keys.conf
@@ -11,4 +11,3 @@ KEY_POWER 1                  /usr/bin/power-button
 KEY_POWER 0                  /usr/bin/power-button-release
 BTN_START+BTN_SELECT 1       batocera-screenshot
 BTN_SELECT+BTN_MODE 1        /usr/bin/dpad-toggle
-KEY_POWER+BTN_MODE 1         /usr/bin/power-led

--- a/board/batocera/allwinner/a133/fsoverlay/usr/bin/dpad-toggle
+++ b/board/batocera/allwinner/a133/fsoverlay/usr/bin/dpad-toggle
@@ -5,18 +5,22 @@ if knulli-board-capability "analogstick"; then
     exit 1
 fi
 
-RUMBLE_FILE="/sys/class/power_supply/axp2202-battery/moto"
-DPAD_STATE_FILE="/sys/class/power_supply/axp2202-battery/nds_pwrkey"
-STATE=$(cat "$DPAD_STATE_FILE")
+DPAD_INPUT_TEMP_FOLDER="/tmp/trimui_inputd"
+DPAD_DISABLED_FILE="/tmp/trimui_inputd/input_no_dpad"
+DPAD_AS_ANALOG_FILE="/tmp/trimui_inputd/input_dpad_to_joystick"
 
-if [ "${STATE}" -eq 0 ]; then
-    echo 1 > "$RUMBLE_FILE" && sleep 0.1 && echo 0 > "$RUMBLE_FILE"
-    echo 2 > "$DPAD_STATE_FILE"
+if [[ ! -d dir ]]; then
+    mkdir "$DPAD_INPUT_TEMP_FOLDER"
+fi
+
+if [ -f "$DPAD_AS_ANALOG_FILE" ]; then
+    knulli-rgb-led-daemon animation achievement
+    rm "$DPAD_DISABLED_FILE"
+    rm "$DPAD_AS_ANALOG_FILE"
 else
-    echo 1 > "$RUMBLE_FILE" && sleep 0.1 && echo 0 > "$RUMBLE_FILE"
-    sleep 0.2
-    echo 1 > "$RUMBLE_FILE" && sleep 0.1 && echo 0 > "$RUMBLE_FILE"
-    echo 0 > "$DPAD_STATE_FILE"
+    knulli-rgb-led-daemon animation achievement
+    touch "$DPAD_DISABLED_FILE"
+    touch "$DPAD_AS_ANALOG_FILE"
 fi
 
 exit 0

--- a/board/batocera/fsoverlay/usr/bin/knulli-board-capability
+++ b/board/batocera/fsoverlay/usr/bin/knulli-board-capability
@@ -45,7 +45,7 @@ checkCapabilityByBoard() {
             HAS_CAPABILITY=true
         fi
     elif [ "$CAPABILITY" = "analogstick" ]; then
-        if [ "$BOARD" = "rg35xx-h" ] || [ "$BOARD" = "rg40xx-h" ] || [ "$BOARD" = "rg40xx-v" ] || [ "$BOARD" = "rg-cubexx" ] || [ "$BOARD" = "trimui-brick" ]; then
+        if [ "$BOARD" = "rg35xx-h" ] || [ "$BOARD" = "rg40xx-h" ] || [ "$BOARD" = "rg40xx-v" ] || [ "$BOARD" = "rg-cubexx" ] || [ "$BOARD" = "trimui-smart-pro" ]; then
             HAS_CAPABILITY=true
         fi
     fi

--- a/package/knulli/knulli-emulationstation/controllers/es_input.cfg
+++ b/package/knulli/knulli-emulationstation/controllers/es_input.cfg
@@ -5315,6 +5315,8 @@
         <input name="up" type="hat" id="0" value="1" />
         <input name="x" type="button" id="7" value="1" code="308" />
         <input name="y" type="button" id="6" value="1" code="307" />
+        <input name="joystick1left" type="axis" id="0" value="-1" code="0" />
+        <input name="joystick1up" type="axis" id="1" value="-1" code="1" />
     </inputConfig>
     <inputConfig type="joystick" deviceName="ANBERNIC-keys" deviceGUID="19000000010000000100000000010000">
         <input name="a" type="button" id="3" value="1" code="304" />


### PR DESCRIPTION
FN+Select should now toggle betweed dpad-as-dpad and dpad-as-analog.