### PR TITLE
Fixed issue with wrong default RGB brightness when booting with HDMI already plugged

### DIFF
--- a/board/batocera/fsoverlay/usr/bin/knulli-rgb-led-daemon
+++ b/board/batocera/fsoverlay/usr/bin/knulli-rgb-led-daemon
@@ -235,7 +235,7 @@ updateAppliedBrightness() {
 
     # If currently plugged to HDMI or brightness calculation crapped out, let's just use the LED brightness at 100%.
     if [ "$HDMI_STATE" = "HDMI=1" ] || [ -z $APPLIED_BRIGHTNESS ]; then
-      APPLIED_BRIGHTNESS=${LAST_LED_VALUES[1]}
+      APPLIED_BRIGHTNESS=$LED_BRIGHTNESS
     fi
   else
     APPLIED_BRIGHTNESS=$LED_BRIGHTNESS


### PR DESCRIPTION
No idea how that happened. Tested with CubeXX, issue seems resolved now.