### PR TITLE
configgen: createPPSSPPConfig: Change RenderingMode to SkipBufferEffects.

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/ppsspp/ppssppConfig.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/ppsspp/ppssppConfig.py
@@ -82,18 +82,18 @@ def createPPSSPPConfig(iniConfig, system):
     iniConfig.set("Graphics", "FrameSkipType", "0") # Use number and not percent
     if system.isOptSet("frameskip") and not system.config["frameskip"] == "automatic":
         iniConfig.set("Graphics", "FrameSkip", str(system.config["frameskip"]))
-    elif system.isOptSet('rendering_mode') and system.getOptBoolean('rendering_mode') == False:
+    elif system.isOptSet('skip_buffer_effects') and system.getOptBoolean('skip_buffer_effects') == True:
         iniConfig.set("Graphics", "FrameSkip", "0")
     else:
         iniConfig.set("Graphics", "FrameSkip", "2")
 
     # Buffered rendering
-    if system.isOptSet('rendering_mode') and system.getOptBoolean('rendering_mode') == False:
-        iniConfig.set("Graphics", "RenderingMode", "0")
-        # Have to force autoframeskip off here otherwise PPSSPP sets rendering mode back to 1.
+    if system.isOptSet('skip_buffer_effects') and system.getOptBoolean('skip_buffer_effects') == True:
+        iniConfig.set("Graphics", "SkipBufferEffects", "True")
+        # Have to force autoframeskip off here.
         iniConfig.set("Graphics", "AutoFrameSkip", "False")
     else:
-        iniConfig.set("Graphics", "RenderingMode", "1")
+        iniConfig.set("Graphics", "SkipBufferEffects", "False")
         # Both internal resolution and auto frameskip are dependent on buffered rendering being on, only check these if the user is actually using buffered rendering.
         # Internal Resolution
         if system.isOptSet('internal_resolution'):

--- a/package/batocera/emulationstation/batocera-es-system/es_features.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_features.yml
@@ -9133,13 +9133,13 @@ ppsspp:
             choices:
                 "OpenGL": 0 (OPENGL)
                 "Vulkan": 3 (VULKAN)
-        rendering_mode:
+        skip_buffer_effects:
             group: ADVANCED OPTIONS
-            prompt: RENDERING MODE
-            description: Skip buffer disables auto frameskip and renders at display output resolution.
+            prompt: SKIP BUFFER EFFECTS
+            description: Skip buffer effects disables auto frameskip and renders at display output resolution.
             choices:
-                "Skip buffer effects": 0
-                "Buffered rendering":  1
+                "Buffered rendering":  false
+                "Skip buffer effects": true
         internal_resolution:
             prompt: RENDERING RESOLUTION
             description: Enhancement. Increase the rendering resolution. Makes 3D objects clearer.


### PR DESCRIPTION
This fixes the broken RenderingMode option in Knulli as PPSSPP changed it to SkipBufferEffects a couple of years ago (https://github.com/hrydgard/ppsspp/commit/519db766b6a251d8d8032236c401babf29e82553).  I have a separate PR open upstream (https://github.com/batocera-linux/batocera.linux/pull/13893) but that configgen has been significantly refactored from this one.

The SkipBufferEffects option is often needed on a TrimUI Smart Pro as PPSSPP often crashes with buffered rendering otherwise (OpenGL driver bug?).