### PR TITLE
Make miyoo flip led blink when is under 5 percent battery

### DIFF
--- a/board/batocera/rockchip/rk3566/miyoo-flip/fsoverlay/etc/init.d/S95ledbatterycheck
+++ b/board/batocera/rockchip/rk3566/miyoo-flip/fsoverlay/etc/init.d/S95ledbatterycheck
@@ -1,0 +1,25 @@
+#!/bin/bash
+ 
+case "$1" in
+    start)
+        led-battery-check-daemon &
+        ;;
+    stop)
+        # Code in here will only be executed on shutdown.
+        echo -n "Shutting down led battery monitor service: "
+        killall led-battery-check-daemon
+        echo "done"
+        ;;
+    restart)
+        echo -n "Restarting led battery monitor service: "
+        killall led-battery-check-daemon
+        led-battery-check-daemon &
+        echo "done"
+        ;;
+    *)
+        # Code in here will be executed in all other conditions.
+        echo "Usage: $0 {start|stop|restart}"
+        ;;
+esac
+ 
+exit $?

--- a/board/batocera/rockchip/rk3566/miyoo-flip/fsoverlay/usr/bin/led-battery-check-daemon
+++ b/board/batocera/rockchip/rk3566/miyoo-flip/fsoverlay/usr/bin/led-battery-check-daemon
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+# --- CONFIGURATION ---
+BATTERY_PATH="/sys/class/power_supply/battery"
+LED_PATH="/sys/class/leds/work"
+THRESHOLD=5                                # Threshold for blinking
+CHECK_INTERVAL=20                          # Check interval in seconds
+# --- CONFIGURATION END ---
+
+trap "echo default-on > $LED_PATH/trigger; exit 0" EXIT     # Keep the led on in case of exiting the daemon
+
+# Check configured paths
+if [ ! -d "$BATTERY_PATH" ]; then
+    echo "Error: Battery not found at $BATTERY_PATH" >&2
+    exit 1
+fi
+if [ ! -d "$LED_PATH" ]; then
+    echo "Error: LED not found at $LED_PATH" >&2
+    exit 1
+fi
+if [ ! -w "$LED_PATH/trigger" ]; then
+    echo "Error: LED trigger not found at $LED_PATH/trigger" >&2
+    exit 1
+fi
+
+echo "Battery monitor for led started. Blink threshold: $THRESHOLD%, Check interval: $CHECK_INTERVAL"
+
+while true; do
+  CAPACITY=$(cat "$BATTERY_PATH/capacity")
+  STATUS=$(cat "$BATTERY_PATH/status") # For checking if it is not charging
+
+  # If battery is under threshold and discharging.
+  if [ "$CAPACITY" -lt "$THRESHOLD" ] && [ "$STATUS" = "Discharging" ]; then
+    # Check if it is already blinking
+    CURRENT_TRIGGER=$(cat "$LED_PATH/trigger")
+    if [[ "$CURRENT_TRIGGER" != *"[timer]"* ]]; then
+      echo "Low battery ($CAPACITY%), starting led blinking..."
+      echo timer > "$LED_PATH/trigger"
+    fi
+  else
+    # If battery is ok or charging stop blinking in case it was enabled.
+    CURRENT_TRIGGER=$(cat "$LED_PATH/trigger")
+    if [[ "$CURRENT_TRIGGER" == *"[timer]"* ]]; then
+      echo "Battery OK ($CAPACITY%) or ($STATUS), stopping blinking..."
+      echo default-on > "$LED_PATH/trigger"
+    fi
+  fi
+  
+  sleep $CHECK_INTERVAL
+done


### PR DESCRIPTION
This commit will make the miyoo flip emit a battery warning making the status led blink when the battery is under 5% of capacity.
I attach a demo video where you can see that also works in-game:
[Demo video](https://photos.google.com/share/AF1QipPR-CMEtyKETuMzxIv2zVSn5meBXhmHoUYzP6LKohNvNe55mjt2oFWGcC5UcuWoTg/photo/AF1QipOzf4xGikFui-V-IRFuiSFWfjZDyU-YPMiKqlvQ?key=Zjl2X2hFZmxndldRV1pYNUxzYWgyam92OFpLd1Vn)