### PR TITLE
[NetPlay] Dynamically detect Wi-Fi interface and route for hotspot support

### DIFF
--- a/package/batocera/core/batocera-configgen/scripts/adhoc_hooks.sh
+++ b/package/batocera/core/batocera-configgen/scripts/adhoc_hooks.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-INTERFACE="wlan0"
 CHANNEL="6"
+INTERFACE=$(ip link show | awk -F: '$2 ~ /wl/ { gsub(/ /, "", $2); print $2 }' | head -n1)
 
 SSID=$(batocera-settings-get wifi.adhoc.ssid)
 PASSPHRASE=$(batocera-settings-get wifi.adhoc.key)
@@ -19,7 +19,9 @@ should_start_ap() {
         return 1
     fi
 
-    ip link show "$INTERFACE" > /dev/null 2>&1 || return 1
+    if [ -z "$INTERFACE" ]; then
+        return 1
+    fi
 
     if ip addr show "$INTERFACE" | grep -q 'inet '; then
         return 1
@@ -35,10 +37,10 @@ case $1 in
 
             ip link set "$INTERFACE" up
             ip addr flush dev "$INTERFACE"
+            sleep 0.1
             ip addr add 192.168.4.1/24 dev "$INTERFACE"
 
-            if [ ! -f "$hostapd_conf" ]; then
-                cat <<EOF > "$hostapd_conf"
+            cat <<EOF > "$hostapd_conf"
 interface=$INTERFACE
 driver=nl80211
 ssid=$SSID
@@ -50,7 +52,6 @@ wpa_passphrase=$PASSPHRASE
 wpa_key_mgmt=WPA-PSK
 rsn_pairwise=CCMP
 EOF
-            fi
 
             hostapd "$hostapd_conf" &
             echo $! > "$hostapd_pid"
@@ -63,7 +64,7 @@ EOF
             echo $! > "$dnsmasq_pid"
 
             for i in {1..100}; do
-                if iw dev wlan0 info | grep -q "type AP"; then
+                if iw dev "$INTERFACE" info | grep -q "type AP"; then
                     break
                 fi
                 sleep 0.1

--- a/package/batocera/core/batocera-scripts/scripts/batocera-wifi
+++ b/package/batocera/core/batocera-scripts/scripts/batocera-wifi
@@ -71,7 +71,7 @@ case "${ACTION}" in
         wait_for_ip down
         ;;
     "getroute")
-        ip route show default dev wlan0 | awk '{print $3}'
+        ip route show default | awk '/^default/ && $0 ~ /wl/ { print $3 }'
         ;;
     *)
         do_help


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/0b1e4c79-a989-4412-b1dc-4eea6bae50ee)

Sometimes, dynamic interface names (e.g., rename_wlan0 instead of wlan0) are assigned.
This patch updates the script to detect the correct interface automatically rather than relying on hardcoded names.
