### PR TITLE
Yet another attempt at fixing TrimUI sleep modes (this time by removing Wi-Fi modules entirely)

### DIFF
--- a/board/batocera/allwinner/a133/fsoverlay/etc/init.d/S03modules
+++ b/board/batocera/allwinner/a133/fsoverlay/etc/init.d/S03modules
@@ -4,24 +4,30 @@ BOARD=$(cat /boot/boot/batocera.board)
 
 case $1 in
     start)
-        if [ "$BOARD" = "trimui-smart-pro" ]; then
-                insmod /lib/modules/4.9.191/xradio_mac_tsp.ko
-		insmod /lib/modules/4.9.191/xradio_core_tsp.ko
-		insmod /lib/modules/4.9.191/xradio_wlan_tsp.ko 
-        else
-		insmod /lib/modules/4.9.191/xradio_mac.ko
-		insmod /lib/modules/4.9.191/xradio_core.ko
-		insmod /lib/modules/4.9.191/xradio_wlan.ko
-        fi
-	for i in /lib/modules/4.9.191/xt*; do insmod $i;done
-	insmod /lib/modules/4.9.191/ipt_REJECT.ko
-	insmod /lib/modules/4.9.191/iptable_filter.ko
-	;;
-	stop)
-	   	rmmod xradio_wlan
-		rmmod xradio_core
-		rmmod xradio_mac
-        ;;
+      if [ "$BOARD" = "trimui-smart-pro" ]; then
+        insmod /lib/modules/4.9.191/xradio_mac_tsp.ko
+        insmod /lib/modules/4.9.191/xradio_core_tsp.ko
+        insmod /lib/modules/4.9.191/xradio_wlan_tsp.ko 
+      else
+        insmod /lib/modules/4.9.191/xradio_mac.ko
+        insmod /lib/modules/4.9.191/xradio_core.ko
+        insmod /lib/modules/4.9.191/xradio_wlan.ko
+      fi
+      for i in /lib/modules/4.9.191/xt*; do insmod $i;done
+      insmod /lib/modules/4.9.191/ipt_REJECT.ko
+      insmod /lib/modules/4.9.191/iptable_filter.ko
+      ;;
+  stop)
+      if [ "$BOARD" = "trimui-smart-pro" ]; then
+        rmmod xradio_wlan_tsp
+        rmmod xradio_core_tsp
+        rmmod xradio_mac_tsp
+      else
+        rmmod xradio_wlan
+        rmmod xradio_core
+        rmmod xradio_mac
+      fi
+      ;;
 esac
 
 exit 0

--- a/board/batocera/allwinner/a133/fsoverlay/etc/pm/sleep.d/99-xradio-wlan
+++ b/board/batocera/allwinner/a133/fsoverlay/etc/pm/sleep.d/99-xradio-wlan
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+BOARD=$(cat /boot/boot/batocera.board)
+# We only want the script to run for these devices
+if [ "$BOARD" != "trimui-brick" ] && [ "$BOARD" != "trimui-smart-pro" ]; then
+    exit 1
+fi
+
+case "${1}" in
+   suspend)
+      # Disable xradio Wi-Fi drivers
+      if [ "$BOARD" = "trimui-smart-pro" ]; then
+        rmmod xradio_wlan_tsp
+      else
+        rmmod xradio_wlan
+      fi
+      ;;
+   thaw|resume)
+      # Re-enable xradio Wi-Fi drivers
+      if [ "$BOARD" = "trimui-smart-pro" ]; then
+        insmod /lib/modules/4.9.191/xradio_wlan.ko
+      else
+        insmod /lib/modules/4.9.191/xradio_wlan_tsp.ko
+      fi
+      
+      # Make sure Wi-Fi isn't soft-blocked
+      rfkill unblock wifi
+      ;;
+esac
+exit 0


### PR DESCRIPTION
The time has come for the latest episode in the award-winning series. Tune in and enjoy the thrill: Will this episode finally be the one that puts your TrimUI handheld to sleep? Or will it again refuse and keep you up all night with its blinding light and its blasting ES background music, draining all your energy and make you go to work tired and worn out in the morning?

There's only one way to find out!

Watch now!

# Seriously though

Instead of simply disabling the Wi-Fi, we now attempt to completely remove the `xradio_wlan.ko` driver modules before suspending and putting them back on wake up. During wake up, it occasionally might happen that `rfkill` soft-blocked Wi-Fi, so we make sure it gets unblocked on wake up, too.

Let's see how that goes, I guess.