### PR TITLE
sleep.d: Add suspend hook to toggle screen

### DIFF
--- a/board/batocera/allwinner/h700/fsoverlay/etc/pm/sleep.d/10-display-off
+++ b/board/batocera/allwinner/h700/fsoverlay/etc/pm/sleep.d/10-display-off
@@ -1,0 +1,13 @@
+#!/bin/bash
+case "$1" in
+    suspend|hibernate)
+        echo disable > /sys/kernel/debug/dispdbg/command
+        echo lcd0 > /sys/kernel/debug/dispdbg/name
+        echo 1 > /sys/kernel/debug/dispdbg/start
+        ;;
+    resume|thaw)
+	echo enable > /sys/kernel/debug/dispdbg/command
+        echo lcd0 > /sys/kernel/debug/dispdbg/name
+        echo 1 > /sys/kernel/debug/dispdbg/start
+        ;;
+esac


### PR DESCRIPTION
Currently there is a 0.5-1 second delay between suspending the device via the power button and the display turning off.

This commit adds a simple sleep.d hook so that when `pm-suspend` is called from `/usr/bin/power-button`, the display will be turned off.  The display will be turned back on when sleep resumes.