### PR TITLE
Changed default Korean font

### DIFF
--- a/package/batocera/fonts/nanum-font/nanum_font.mk
+++ b/package/batocera/fonts/nanum-font/nanum_font.mk
@@ -11,7 +11,7 @@ NANUM_FONT_TARGET_DIR=$(TARGET_DIR)/usr/share/fonts/truetype/nanum
 
 define NANUM_FONT_INSTALL_TARGET_CMDS
 	@mkdir -p $(NANUM_FONT_TARGET_DIR)
-	@cp $(@D)/ttf/NanumSquare_acB.ttf $(NANUM_FONT_TARGET_DIR)
+	@cp $(@D)/ttf/NanumGothicBold.ttf $(NANUM_FONT_TARGET_DIR)
 endef
 
 $(eval $(generic-package))

--- a/package/batocera/utils/od-commander/Config.in
+++ b/package/batocera/utils/od-commander/Config.in
@@ -15,11 +15,11 @@ if BR2_PACKAGE_OD_COMMANDER
 
 config BR2_PACKAGE_OD_COMMANDER_FONTS
 	string "Font stack"
-	default "{\"/usr/share/fonts/dejavu/DejaVuSansCondensed.ttf\",10},{\"/usr/share/fonts/truetype/nanum/NanumSquare_acB.ttf\",10},{\"/usr/share/fonts/truetype/droid/DroidSansFallback.ttf\",9}"
+	default "{\"/usr/share/fonts/dejavu/DejaVuSansCondensed.ttf\",10},{\"/usr/share/fonts/truetype/nanum/NanumGothicBold.ttf\",10},{\"/usr/share/fonts/truetype/droid/DroidSansFallback.ttf\",9}"
 
 config BR2_PACKAGE_OD_COMMANDER_FONTS_LOW_DPI
 	string "Font stack for low DPI displays"
-	default "{RES_DIR\"Fiery_Turk.ttf\",8},{\"/usr/share/fonts/dejavu/DejaVuSansCondensed.ttf\",10},{\"/usr/share/fonts/truetype/nanum/NanumSquare_acB.ttf\",10},{\"/usr/share/fonts/truetype/droid/DroidSansFallback.ttf\",9}"
+	default "{RES_DIR\"Fiery_Turk.ttf\",8},{\"/usr/share/fonts/dejavu/DejaVuSansCondensed.ttf\",10},{\"/usr/share/fonts/truetype/nanum/NanumGothicBold.ttf\",10},{\"/usr/share/fonts/truetype/droid/DroidSansFallback.ttf\",9}"
 
 config BR2_PACKAGE_OD_COMMANDER_AUTOSCALE
 	bool "Enable automatic screen size and PPU detection"


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/10634a43-8746-453f-af0b-593ae9e3555f)

After the KNULLI Gladiator release, there was a lot of feedback from the Korean community.

The previous NanumSquare_acB font had issues rendering English characters in RetroArch,
so I updated it to the newly improved font: NanumGothicBold.

This change should resolve the Korean font rendering issues.
