### PR TITLE
Introduced Bezel Project to board capability for TrimUI Brick

### DIFF
--- a/board/batocera/fsoverlay/usr/bin/knulli-board-capability
+++ b/board/batocera/fsoverlay/usr/bin/knulli-board-capability
@@ -60,6 +60,10 @@ checkCapabilityByBoard() {
         if [ "$BOARD" = "rg35xx-plus" ] || [ "$BOARD" = "rg35xx-h" ] || [ "$BOARD" = "rg35xx-2024" ] || [ "$BOARD" = "rg35xx-sp" ] || [ "$BOARD" = "rg28xx" ] || [ "$BOARD" = "rg40xx-h" ] || [ "$BOARD" = "rg40xx-v" ] || [ "$BOARD" = "rg-cubexx" ] || [ "$BOARD" = "rg34xx" ] || [ "$BOARD" = "trimui-smart-pro" ] || [ "$BOARD" = "trimui-brick" ] || [ "$BOARD" = "miyoo-flip" ] || [ "$BOARD" = "rg-arc-s" ] || [ "$BOARD" = "powkiddy-rgb30" ]; then
             HAS_CAPABILITY=true
         fi
+    elif [ "$CAPABILITY" = "bezelproject" ]; then
+        if [ "$BOARD" = "trimui-smart-pro" ]; then
+            HAS_CAPABILITY=true
+        fi
     fi
     
 }


### PR DESCRIPTION
Bezel Project is pointless on devices without 16:9 screens, it might even cause issues. In the future, the option to download Bezel Project is only available on devices which have Bezel Project to board capability. (See also here: https://github.com/knulli-cfw/batocera-emulationstation/pull/54)