### PR TITLE
Updated Linux firmware link

### DIFF
--- a/package/batocera/firmwares/alllinuxfirmwares/alllinuxfirmwares.mk
+++ b/package/batocera/firmwares/alllinuxfirmwares/alllinuxfirmwares.mk
@@ -6,7 +6,7 @@
 
 ALLLINUXFIRMWARES_VERSION = 20241110
 ALLLINUXFIRMWARES_SOURCE = linux-firmware-$(ALLLINUXFIRMWARES_VERSION).tar.gz
-ALLLINUXFIRMWARES_SITE = https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git/snapshot
+ALLLINUXFIRMWARES_SITE = https://www.kernel.org/pub/linux/kernel/firmware
 
 # exclude some dirs not required on batocera
 ALLLINUXFIRMWARES_REMOVE_DIRS = $(@D)/liquidio $(@D)/netronome $(@D)/mellanox \


### PR DESCRIPTION
The current link is not working anymore to download the Linux firmware, updating the link fixes it.