### PR TITLE
knulli-emulationstation: es_input: RG34XX-SP: Swap L1/L2 and R1/R2.

### DIFF
--- a/package/knulli/knulli-emulationstation/controllers/es_input.cfg
+++ b/package/knulli/knulli-emulationstation/controllers/es_input.cfg
@@ -5620,12 +5620,12 @@
 	<input name="joystick1up" type="axis" id="1" value="-1" code="3" />
 	<input name="joystick2left" type="axis" id="2" value="-1" code="4" />
 	<input name="joystick2up" type="axis" id="3" value="-1" code="5" />
-	<input name="l2" type="button" id="7" value="1" code="308" />
+	<input name="l2" type="button" id="13" value="1" code="314" />
 	<input name="l3" type="button" id="12" value="1" code="313" />
 	<input name="left" type="hat" id="0" value="8" />
-	<input name="pagedown" type="button" id="14" value="1" code="315" />
-	<input name="pageup" type="button" id="13" value="1" code="314" />
-	<input name="r2" type="button" id="8" value="1" code="309" />
+	<input name="pagedown" type="button" id="8" value="1" code="309" />
+	<input name="pageup" type="button" id="7" value="1" code="308" />
+	<input name="r2" type="button" id="14" value="1" code="315" />
 	<input name="r3" type="button" id="15" value="1" code="316" />
 	<input name="right" type="hat" id="0" value="2" />
 	<input name="select" type="button" id="9" value="1" code="310" />


### PR DESCRIPTION
The buttons are backwards, this fixes them.