### PR TITLE
Added factory reset script

### DIFF
--- a/board/batocera/fsoverlay/usr/bin/knulli-factory-reset
+++ b/board/batocera/fsoverlay/usr/bin/knulli-factory-reset
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+# -f Parameter overrides confirmation prompt
+if [ $# -eq 0 ] || [ $1 != "-f" ]; then
+  read -p "Are you sure that you want to reset to factory settings? (y/n)" -n 1 -r
+  echo
+  if [[ ! $REPLY =~ ^[Yy]$ ]]
+  then
+    exit 1
+  fi
+fi
+
+# Turn off the screen to avoid any weird behavior that might scare users
+batocera-brightness dispoff
+amixer set Master mute
+
+# Kill EmulationStation to be sure it will not write any existing settings
+/etc/init.d/S31emulationstation stop
+
+# Move the old system folder
+mv /userdata/system /userdata/system_$(date -d "today" +"%Y%m%d%H%M")
+
+# Remove PortMaster launch script if PortMaster was installed
+if [ -f /userdata/roms/ports/PortMaster.sh ]; then
+  rm /userdata/roms/ports/PortMaster.sh
+fi
+
+# Put the PortMaster installer back
+if [ ! -f /userdata/roms/ports/Install.PortMaster.sh ]; then
+  cp /usr/share/batocera/datainit/roms/ports/Install.PortMaster.sh /userdata/roms/ports/
+fi
+
+# Reboot
+knulli-shutdown -r
+
+exit 0

--- a/board/batocera/fsoverlay/usr/bin/knulli-factory-reset
+++ b/board/batocera/fsoverlay/usr/bin/knulli-factory-reset
@@ -17,17 +17,18 @@ amixer set Master mute
 # Kill EmulationStation to be sure it will not write any existing settings
 /etc/init.d/S31emulationstation stop
 
+BACKUP_FOLDER_PATH="/userdata/system.$(date -d "today" +"%Y%m%d%H%M")"
+
 # Move the old system folder
-mv /userdata/system /userdata/system_$(date -d "today" +"%Y%m%d%H%M")
+mv /userdata/system $BACKUP_FOLDER_PATH
 
-# Remove PortMaster launch script if PortMaster was installed
-if [ -f /userdata/roms/ports/PortMaster.sh ]; then
-  rm /userdata/roms/ports/PortMaster.sh
-fi
+# Re-populate the system folder 
+/etc/init.d/S12populateshare start
 
-# Put the PortMaster installer back
-if [ ! -f /userdata/roms/ports/Install.PortMaster.sh ]; then
-  cp /usr/share/batocera/datainit/roms/ports/Install.PortMaster.sh /userdata/roms/ports/
+# Put PortMaster back if it was installed
+if [ ! -f $BACKUP_FOLDER_PATH/.local/share/PortMaster ]; then
+  mkdir -p /userdata/system/.local/share/
+  mv $BACKUP_FOLDER_PATH/.local/share/PortMaster /userdata/system/.local/share/PortMaster
 fi
 
 # Reboot


### PR DESCRIPTION
Can be launched directly from ES, see here: https://github.com/knulli-cfw/batocera-emulationstation/pull/62

* Ask for confirmation (when launched from bash, can be overriden via `-f`)
* Turn off screen
* Turn off audio
* Stop EmulationStation (to make sure it won't write anything to the system folder anymore)
* Rename `system` to `system_<current date and time>`
* Recreate `system` via S21
* Move PortMaster installation from backup to new `system` folder
* Reboot