### PR TITLE
[NetPlay] Add has_ap_mode check for hotspot support detection

### DIFF
--- a/package/batocera/core/batocera-configgen/scripts/adhoc_hooks.sh
+++ b/package/batocera/core/batocera-configgen/scripts/adhoc_hooks.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 CHANNEL="6"
-INTERFACE=$(ip link show | awk -F: '$2 ~ /wl/ { gsub(/ /, "", $2); print $2 }' | head -n1)
+INTERFACE=$(batocera-wifi get_interface)
 
 SSID=$(batocera-settings-get wifi.adhoc.ssid)
 PASSPHRASE=$(batocera-settings-get wifi.adhoc.key)

--- a/package/batocera/core/batocera-scripts/scripts/batocera-wifi
+++ b/package/batocera/core/batocera-scripts/scripts/batocera-wifi
@@ -30,6 +30,24 @@ wait_for_ip() {
     done
 }
 
+get_route() {
+    echo $(ip route show default | awk '/^default/ && $0 ~ /wl/ { print $3 }')
+}
+
+get_interface() {
+    echo $(ip link show | awk -F: '$2 ~ /w[l]/ { gsub(/ /, "", $2); print $2 }' | head -n1)
+}
+
+has_ap_mode() {
+    WIFI_DEV=$(get_interface)
+    PHY=$(basename "$(readlink /sys/class/net/${WIFI_DEV}/phy80211)")
+    if iw phy "${PHY}" info | sed -n '/Supported interface modes/,/^[^*]*$/s|^.*[*] ||p' | grep -q 'AP'; then
+        exit 0
+    else
+        exit 1
+    fi
+}
+
 if [ $# -eq 0 ]; then
     do_help
     exit 1
@@ -70,8 +88,14 @@ case "${ACTION}" in
         /etc/init.d/S20connman reload
         wait_for_ip down
         ;;
-    "getroute")
-        ip route show default | awk '/^default/ && $0 ~ /wl/ { print $3 }'
+    "get_route")
+        get_route
+        ;;
+    "get_interface")
+        get_interface
+        ;;
+    "has_ap_mode")
+        has_ap_mode
         ;;
     *)
         do_help


### PR DESCRIPTION
Adds a new `has_ap_mode` flag to detect whether the current Wi-Fi interface supports Access Point (AP) mode.
This allows the UI to adjust hotspot-related options accordingly.