### PR TITLE
Ensure all images for h700 are outputted

### DIFF
--- a/package/batocera/core/batocera-system/Config.in
+++ b/package/batocera/core/batocera-system/Config.in
@@ -551,8 +551,7 @@ config BR2_TARGET_BATOCERA_IMAGES_DEFINITIONS
 	default "allwinner/h5/tritium-h5 allwinner/h5/orangepi-pc2"					if BR2_PACKAGE_BATOCERA_TARGET_H5
 	default "allwinner/h6/orangepi-3-lts allwinner/h6/orangepi-3 allwinner/h6/orangepi-one-plus"	if BR2_PACKAGE_BATOCERA_TARGET_H6
 	default "allwinner/h616/orangepi-zero2 allwinner/h616/orangepi-zero3 allwinner/h616/x96-mate"	if BR2_PACKAGE_BATOCERA_TARGET_H616
-#	default "allwinner/h700/rg35xx-sp allwinner/h700/rg35xx-plus allwinner/h700/rg35xx-h allwinner/h700/rg40xx-h allwinner/h700/rg40xx-v allwinner/h700/rg-cubexx allwinner/h700/rg28xx allwinner/h700/rg34xx allwinner/h700/rg34xx-sp" \
-	default "allwinner/h700/rg35xx-pro" \
+	default "allwinner/h700/rg35xx-sp allwinner/h700/rg35xx-plus allwinner/h700/rg35xx-h allwinner/h700/rg40xx-h allwinner/h700/rg40xx-v allwinner/h700/rg-cubexx allwinner/h700/rg28xx allwinner/h700/rg34xx allwinner/h700/rg34xx-sp allwinner/h700/rg35xx-pro" \
 													if BR2_PACKAGE_BATOCERA_TARGET_H700
 	default "allwinner/a133/trimui-smart-pro allwinner/a133/trimui-brick allwinner/a133/magicx-zero-28"	if BR2_PACKAGE_BATOCERA_TARGET_A133
 	default "allwinner/r16/miyoo-a30"								if BR2_PACKAGE_BATOCERA_TARGET_SUNXI_R16


### PR DESCRIPTION
I was very confused after trying to build for the first time and getting images only for rg35xx-pro.

Turns out it was hardcoded as the only image to output, I assume as part of a test when support for it was added.

This reverts to outputting all images for the h700 target, while adding rg35xx-pro to the list.