### PR TITLE
Enabled bezels for standalone emulators and updated default bezels

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/emulatorlauncher.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/emulatorlauncher.py
@@ -303,8 +303,8 @@ def getHudBezel(system: Emulator, generator: Generator, rom: str, gameResolution
         eslog.info(f"bezel size read from {overlay_png_file}")
 
     # max cover proportion and ratio distortion
-    max_cover = 0.05 # 5%
-    max_ratio_delta = 0.01
+    max_cover = 0.50 # 50%
+    max_ratio_delta = 0.5
 
     screen_ratio = gameResolution["width"] / gameResolution["height"]
     bezel_ratio  = bezel_width / bezel_height

--- a/package/knulli/retroarch/knulli-bezels/knulli-bezels.mk
+++ b/package/knulli/retroarch/knulli-bezels/knulli-bezels.mk
@@ -3,8 +3,8 @@
 # knulli bezels
 #
 ################################################################################
-# Version.: Commits on June 8, 2025
-KNULLI_BEZELS_VERSION = 391bc8099649b9344afbe007a25c788a6e89fcbb
+# Version.: Commits on July 5, 2025
+KNULLI_BEZELS_VERSION = 38b4327e6ac61e79d2d59a0d623d465948df5d69
 KNULLI_BEZELS_SITE = $(call github,chrizzo-hb,knulli-bezels,$(KNULLI_BEZELS_VERSION))
 
 define KNULLI_BEZELS_INSTALL_TARGET_CMDS


### PR DESCRIPTION
Batocera code about bezels was written for 16:9 aspect ratio bezels. There's a function which calculates the percentage of the screen that would be covered by the bezel. By increasing the allowed percentage, we enable standalone emulator bezels implicitly.

Since those emulators do not support modifying the viewport, I balanced out the corresponding bezels of the default bezel set and made sure that covered black bars are even on both sides of the screen.