### PR TITLE
Disable bezels on MPV by default

### DIFF
--- a/package/batocera/core/batocera-configgen/configs/configgen-defaults.yml
+++ b/package/batocera/core/batocera-configgen/configs/configgen-defaults.yml
@@ -357,6 +357,8 @@ moonlight:
     bezel: none
     hud_support: false
 mpv:
+  emulator: mpv
+  core:     mpv
   options:
     bezel: none
     hud_support: false

--- a/package/batocera/core/batocera-configgen/configs/configgen-defaults.yml
+++ b/package/batocera/core/batocera-configgen/configs/configgen-defaults.yml
@@ -356,6 +356,10 @@ moonlight:
   options:
     bezel: none
     hud_support: false
+mpv:
+  options:
+    bezel: none
+    hud_support: false
 mrboom:
   emulator: libretro
   core:     mrboom


### PR DESCRIPTION
Depending on the selected bezel set, Knulli seems to attempt to add bezels to MPV in certain (unlikely) cases.

Alpha users complained about it, mostly because they were using a build that had the messed up bezel folder (old and new bezels, not cleaned up, yet), so the issue shouldn't arise with the default-knulli bezel pack anyway.

However, to be safe, let's just disable them entirely. Both, bezels and HUD. (I believe that due to HUD being disabled, bezels wouldn't be applied anyway, but let's be safe.)