### PR TITLE
READ DESCRIPTION - Disable standalone N64 bezels on A133 devices

### DIFF
--- a/package/batocera/core/batocera-configgen/configs/configgen-defaults-a133.yml
+++ b/package/batocera/core/batocera-configgen/configs/configgen-defaults-a133.yml
@@ -30,6 +30,13 @@ naomi:
 n64:
   emulator: libretro
   core:     parallel_n64
+  options:
+    hud_support: false
+n64dd:
+  emulator: libretro
+  core:     parallel_n64
+  options:
+    hud_support: false
 cdi:
   emulator: libretro
   core:     same_cdi


### PR DESCRIPTION
### Issue

On A133 devices (TrimUI Smart Pro & Brick), standalone N64 emulators crash when Knulli attempts to apply a bezel.

### Not a fix, just a workaround

I'd prefer if the **underlying issue** gets fixed. However, I understand the user frustration about games not working after switching emulators when a global bezel set is chosen which provides an N64 bezel or a generic fallback bezel.

Therefore **if** we do not have time to **fix the underlying issue**, this PR might be merged as a band aid to **avoid user frustration** and **postpone finding a solution for the real issue**.