### PR TITLE
Retro Achievements integration for standalone PPSSPP via configgen

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/ppsspp/ppssppConfig.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/ppsspp/ppssppConfig.py
@@ -16,6 +16,7 @@ eslog = logging.getLogger(__name__)
 
 ppssppConfig: Final   = PPSSPP_PSP_SYSTEM_DIR / 'ppsspp.ini'
 ppssppControls: Final = PPSSPP_PSP_SYSTEM_DIR / 'controls.ini'
+ppssppRetroach: Final = PPSSPP_PSP_SYSTEM_DIR / 'ppsspp_retroachievements.dat'
 
 def writePPSSPPConfig(system: Emulator):
     iniConfig = CaseSensitiveConfigParser(interpolation=None)
@@ -30,6 +31,11 @@ def writePPSSPPConfig(system: Emulator):
     # Save the ini file
     with ensure_parents_and_open(ppssppConfig, 'w') as configfile:
         iniConfig.write(configfile)
+
+def writeRetroAchievements(token: str):
+    if token:
+        with ensure_parents_and_open(ppssppRetroach, 'w') as retroach_file:
+            retroach_file.write(token)
 
 def createPPSSPPConfig(iniConfig, system):
 
@@ -181,6 +187,38 @@ def createPPSSPPConfig(iniConfig, system):
     iniConfig.set("Upgrade", "UpgradeMessage", "")
     iniConfig.set("Upgrade", "UpgradeVersion", "")
     iniConfig.set("Upgrade", "DismissedVersion", "")
+
+    ## [RetroAchievements]
+    if not iniConfig.has_section("Achievements"):
+        iniConfig.add_section("Achievements")
+        
+        # Achievements enabled
+        if system.isOptSet('retroachievements') and system.getOptBoolean('retroachievements') == True:
+          iniConfig.set("Achievements", "AchievementsEnable", "True")
+        else:
+          iniConfig.set("Achievements", "AchievementsEnable", "False")
+        
+        # Achievements credentials
+        iniConfig.set("Achievements", "AchievementsUserName", system.config.get("retroachievements.username", ""))
+        writeRetroAchievements(str(system.config.get("retroachievements.token", None)))
+        
+        # Achievements hardcore mode
+        if system.isOptSet('retroachievements.hardcore') and system.getOptBoolean('retroachievements.hardcore') == True:
+            iniConfig.set("Achievements", "AchievementsChallengeMode", "True")
+        else:
+            iniConfig.set("Achievements", "AchievementsChallengeMode", "False")
+        
+        # Achievements encore mode
+        if system.isOptSet('retroachievements.encore') and system.getOptBoolean('retroachievements.encore') == True:
+            iniConfig.set("Achievements", "AchievementsEncoreMode", "True")
+        else:
+            iniConfig.set("Achievements", "AchievementsEncoreMode", "False")
+
+        # Achievements sound enabled
+        if system.isOptSet("retroachievements.sound") and system.config["retroachievements.sound"] != "none":
+            iniConfig.set("Achievements", "AchievementsSoundEffects", "True")
+        else:
+            iniConfig.set("Achievements", "AchievementsSoundEffects", "False")
 
     # Custom : allow the user to configure directly PPSSPP via batocera.conf via lines like : ppsspp.section.option=value
     for user_config in system.config:

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/ppsspp/ppssppConfig.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/ppsspp/ppssppConfig.py
@@ -192,33 +192,33 @@ def createPPSSPPConfig(iniConfig, system):
     if not iniConfig.has_section("Achievements"):
         iniConfig.add_section("Achievements")
         
-        # Achievements enabled
-        if system.isOptSet('retroachievements') and system.getOptBoolean('retroachievements') == True:
-          iniConfig.set("Achievements", "AchievementsEnable", "True")
-        else:
-          iniConfig.set("Achievements", "AchievementsEnable", "False")
-        
-        # Achievements credentials
-        iniConfig.set("Achievements", "AchievementsUserName", system.config.get("retroachievements.username", ""))
-        writeRetroAchievements(str(system.config.get("retroachievements.token", None)))
-        
-        # Achievements hardcore mode
-        if system.isOptSet('retroachievements.hardcore') and system.getOptBoolean('retroachievements.hardcore') == True:
-            iniConfig.set("Achievements", "AchievementsChallengeMode", "True")
-        else:
-            iniConfig.set("Achievements", "AchievementsChallengeMode", "False")
-        
-        # Achievements encore mode
-        if system.isOptSet('retroachievements.encore') and system.getOptBoolean('retroachievements.encore') == True:
-            iniConfig.set("Achievements", "AchievementsEncoreMode", "True")
-        else:
-            iniConfig.set("Achievements", "AchievementsEncoreMode", "False")
+    # Achievements enabled
+    if system.isOptSet('retroachievements') and system.getOptBoolean('retroachievements') == True:
+      iniConfig.set("Achievements", "AchievementsEnable", "True")
+    else:
+      iniConfig.set("Achievements", "AchievementsEnable", "False")
+    
+    # Achievements credentials
+    iniConfig.set("Achievements", "AchievementsUserName", system.config.get("retroachievements.username", ""))
+    writeRetroAchievements(str(system.config.get("retroachievements.token", None)))
+    
+    # Achievements hardcore mode
+    if system.isOptSet('retroachievements.hardcore') and system.getOptBoolean('retroachievements.hardcore') == True:
+        iniConfig.set("Achievements", "AchievementsChallengeMode", "True")
+    else:
+        iniConfig.set("Achievements", "AchievementsChallengeMode", "False")
+    
+    # Achievements encore mode
+    if system.isOptSet('retroachievements.encore') and system.getOptBoolean('retroachievements.encore') == True:
+        iniConfig.set("Achievements", "AchievementsEncoreMode", "True")
+    else:
+        iniConfig.set("Achievements", "AchievementsEncoreMode", "False")
 
-        # Achievements sound enabled
-        if system.isOptSet("retroachievements.sound") and system.config["retroachievements.sound"] != "none":
-            iniConfig.set("Achievements", "AchievementsSoundEffects", "True")
-        else:
-            iniConfig.set("Achievements", "AchievementsSoundEffects", "False")
+    # Achievements sound enabled
+    if system.isOptSet("retroachievements.sound") and system.config["retroachievements.sound"] != "none":
+        iniConfig.set("Achievements", "AchievementsSoundEffects", "True")
+    else:
+        iniConfig.set("Achievements", "AchievementsSoundEffects", "False")
 
     # Custom : allow the user to configure directly PPSSPP via batocera.conf via lines like : ppsspp.section.option=value
     for user_config in system.config:


### PR DESCRIPTION
With this configgen update, standalone PPSSPP will be configured to use RetroAchievements according to whatever was set up in ES (as much as possible, some features are still only available in libretro cores).

This configgen change sets the following PPSSPP config values based on ES settings:

* Retro Achievements on/off
* Retro Achievements username
* Retro Achievements login token
* Retro Achievements encore mode on/off
* Retro Achievements hardcore mode on/off
* Retro Achievements sound effects on/off

Implementation is based on this Batocera commit [right here](https://github.com/batocera-linux/batocera.linux/commit/7bcb98f833b157053e95ae229f173f9310053263) and a prototype from a community member in our Discord [here](https://discord.com/channels/1173228527605272666/1229419106332311665/1399669869993263155).

I extended the approach to pass on all possible RA-related settings, not just credentials and user name.

Seems to work fine so far, tested on my RG CubeXX.