### PR TITLE
Fix RetroAchievements connectivity check

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroConfig.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroConfig.py
@@ -4,6 +4,7 @@ import os
 import json
 import logging
 import subprocess
+import socket
 import xml.etree.ElementTree as ET
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
@@ -82,25 +83,19 @@ systemNetplayModes = {'host', 'client', 'spectator'}
 # Cores that require .slang shaders (even on OpenGL, not only Vulkan)
 coreForceSlangShaders = { 'mupen64plus-next' }
 
-def connected_to_internet() -> bool:
-    # Try 1.1.1.1 first
-    cmd = ["timeout", "1", "ping", "-c", "1", "-t", "255", "1.1.1.1"]
-    process = subprocess.Popen(cmd)
-    process.wait()
-    if process.returncode == 0:
-        eslog.debug("Connected to the internet")
-        return True
-    else:
-        # Try 8.8.8.8 if 1.1.1.1 fails
-        cmd = ["timeout", "1", "ping", "-c", "1", "-t", "255", "8.8.8.8"]
-        process = subprocess.Popen(cmd)
-        process.wait()
-        if process.returncode == 0:
-            eslog.debug("Connected to the internet")
+def connected_to_internet(timeout: float = 1.0) -> bool:
+    """
+    Consider online if we can open a TCP socket to RetroAchievements (HTTPS 443).
+    """
+    host, port = "retroachievements.org", 443
+    try:
+        with socket.create_connection((host, port), timeout=timeout):
+            eslog.debug(f"Connected to {host}:{port}")
             return True
-        else:
-            eslog.error("Not connected to the internet")
-            return False
+    except Exception as e:
+        eslog.debug(f"Connectivity check to {host}:{port} failed: {e}")
+        eslog.error("Not connected to the internet (RetroAchievements unreachable)")
+        return False
 
 def writeLibretroConfig(generator: Generator, retroconfig: UnixSettings, system: Emulator, controllers: ControllerMapping, metadata: Mapping[str, str], guns: GunMapping, wheels: DeviceInfoMapping, rom: Path, bezel: str | None, shaderBezel: bool, gameResolution: Resolution, gfxBackend: str) -> None:
     writeLibretroConfigToFile(retroconfig, createLibretroConfig(generator, system, controllers, metadata, guns, wheels, rom, bezel, shaderBezel, gameResolution, gfxBackend))


### PR DESCRIPTION
🛠️ Fix RetroAchievements connectivity check

#### What changed
- Replaced the old `connected_to_internet()` function (which relied on ICMP `ping` to `1.1.1.1` and `8.8.8.8`) with a direct **TCP socket check to `retroachievements.org:443`**.  
- The new implementation simply verifies whether the RetroAchievements HTTPS service is reachable.


#### Why this is better

**Checks the real endpoint**  
RetroAchievements only uses HTTPS. Testing `retroachievements.org:443` directly ensures the service you actually need for login/stats/achievements is reachable.

**Avoids false negatives**  
Many networks (especially hotels, corporate Wi-Fi, or captive portals) block ICMP, which made the old ping-based test fail even when RA worked fine.   → I’ve run into this myself when traveling for work, being stuck in hotels with ICMP blocked forced me to use a manual workaround (`global.retroarch.cheevos_enable = true`) to bypass the script.

**Simpler and faster**  
No subprocess calls to `ping`, no platform-specific behavior differences (`timeout` vs BusyBox vs coreutils`). Just one lightweight socket check.

**Reproducible issue in Knulli**  
This bug was first discovered while testing Knulli on SBCs, where `cheevos_enable = false` where written into `retroarchcustom.cfg` even when online.   The difference came from how `ping/timeout` behave on different boards and Wi-Fi drivers. With this change, the logic is uniform across devices.


#### Issue addressed

- Fixes RetroAchievements being **always disabled** in `retroarchcustom.cfg` despite having working internet access.  
- Users no longer need to override settings manually.  


✅ **Impact**: RetroAchievements now enable correctly when `global.retroachievements=1` and the selected core supports RA.   Only if `retroachievements.org:443` is unreachable will achievements be forced off.  

**Link to discussion on Discord about the issue** [**here**](https://discord.com/channels/1173228527605272666/1307190659370975353/1408787476469907561)