### PR TITLE
Support configuring the new "max_prefetch_threads" option for pico-8 0.2.7

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/lexaloffle/lexaloffleGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/lexaloffle/lexaloffleGenerator.py
@@ -127,12 +127,12 @@ class LexaloffleGenerator(Generator):
         else:
             config_settings["foreground_sleep_ms"] = "1"
 
-        # Number of threads to prefetch carts in splore
-        # 0 as default to only prefetch the visited carts, which will prevent many unexpected carts showing up in the pico8/splore folder
-        if system.isOptSet("max_prefetch_threads"):
-            config_settings["max_prefetch_threads"] = system.config['max_prefetch_threads']
+        # Number of threads to pre-fetch carts in splore
+        # 4 as default
+        if system.isOptSet("pico8_max_prefetch_threads"):
+            config_settings["max_prefetch_threads"] = system.config['pico8_max_prefetch_threads']
         else:
-            config_settings["max_prefetch_threads"] = "0"
+            config_settings["max_prefetch_threads"] = "4"
 
         # Write config_settings to config.txt
         self.write_config(config_settings)

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/lexaloffle/lexaloffleGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/lexaloffle/lexaloffleGenerator.py
@@ -127,6 +127,13 @@ class LexaloffleGenerator(Generator):
         else:
             config_settings["foreground_sleep_ms"] = "1"
 
+        # Number of threads to prefetch carts in splore
+        # 0 as default to only prefetch the visited carts, which will prevent many unexpected carts showing up in the pico8/splore folder
+        if system.isOptSet("max_prefetch_threads"):
+            config_settings["max_prefetch_threads"] = system.config['max_prefetch_threads']
+        else:
+            config_settings["max_prefetch_threads"] = "0"
+
         # Write config_settings to config.txt
         self.write_config(config_settings)
 

--- a/package/batocera/emulationstation/batocera-es-system/es_features.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_features.yml
@@ -11495,13 +11495,13 @@ lexaloffle:
             pico8_max_prefetch_threads:
                 group: ADVANCED OPTIONS
                 prompt: CART PREFETCH THREADS
-                description: How many threads to use for downloading carts in the background while in splore. 0 to turn off pre-fetching -> carts are only downloaded once they are selected
+                description: Threads used for pre-fetching carts in Splore (0 = disabled, download only when selected).
                 choices:
-                    "0 (Default)":  0
+                    "0":            0
                     "1":            1
                     "2":            2
                     "3":            3
-                    "4":            4
+                    "4 (Default)":  4
                     "5":            5
                     "6":            6
                     "7":            7

--- a/package/batocera/emulationstation/batocera-es-system/es_features.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_features.yml
@@ -11492,6 +11492,22 @@ lexaloffle:
                     "8":            8
                     "9":            9
                     "10":           10
+            pico8_max_prefetch_threads:
+                group: ADVANCED OPTIONS
+                prompt: CART PREFETCH THREADS
+                description: How many threads to use for downloading carts in the background while in splore. 0 to turn off pre-fetching -> carts are only downloaded once they are selected
+                choices:
+                    "0 (Default)":  0
+                    "1":            1
+                    "2":            2
+                    "3":            3
+                    "4":            4
+                    "5":            5
+                    "6":            6
+                    "7":            7
+                    "8":            8
+                    "9":            9
+                    "10":           10
 
 ecwolf:
   features: [padtokeyboard]


### PR DESCRIPTION
### Summary
- Added support for the newly released `max_prefetch_threads` config option for pico-8 0.2.7 released on 8/16
- Updated `es_features.yml` to make it configurable in `Game Settings -> PER SYSTEM ADVANCED CONFIGURATION -> Pico-8` menu
- Today default value of this option is 4, if updated to pico-8 0.2.7, meaning there are 4 threads concurrently downloading carts when using Splore
  - I set the default to 0 (equivalent to turning it off) as this is the previous behavior and makes more sense for Knulli. This new option, when not set to 0, will very quickly download a lot of unintended carts to the roms/pico8/ folder when browsing games in Splore, resulting in over 100 carts showing up in the pico-8 game list menu, which was very annoying
- Confimed pico-8 will ignore unrecognized config, so this is backward compatible

### Testing
Built/flashed the image to my rg cubexx to confirm this is working as expected