### PR TITLE
Fix artwork scraping for Ports system (update platform to pc windows)

### DIFF
--- a/package/batocera/emulationstation/batocera-es-system/es_systems.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_systems.yml
@@ -2427,7 +2427,7 @@ ports:
   release:
   hardware: port
   extensions: [sh, squashfs]
-  platform: pc
+  platform: pc windows
   group: ports
   path: ports
   emulators:


### PR DESCRIPTION
This update changes the Ports system platform value from "pc" to "pc windows" in es_systems.yml.

ScreenScraper.fr categorizes PC/Windows games under the "pc windows" platform. The previous value ("pc") caused artwork scraping to fail for all items in the Ports category.

I tested this change locally by modifying es_systems.cfg on my device. Updating the platform field to "pc windows" fully restored artwork scraping functionality for Ports.

This change aligns the platform metadata with ScreenScraper’s expected platform identifier and resolves the issue.